### PR TITLE
SWE-agent[bot] PR to fix: Github repo search buggy

### DIFF
--- a/sweagent/api/static/app.js
+++ b/sweagent/api/static/app.js
@@ -58,9 +58,10 @@ document.addEventListener('DOMContentLoaded', function() {
     // GitHub repository autocomplete functionality
     let autocompleteTimeout = null;
     let selectedAutocompleteIndex = -1;
+    let isSearching = false; // Track if a search is in progress
 
     function showGitHubAutocomplete(query) {
-        if (query.length < 2) {
+        if (query.length < 3) { // Minimum 3 characters for better results
             githubRepoAutocomplete.classList.add('hidden');
             return;
         }
@@ -70,7 +71,12 @@ document.addEventListener('DOMContentLoaded', function() {
             clearTimeout(autocompleteTimeout);
         }
 
-        // Debounce the search request
+        // Show loading state
+        isSearching = true;
+        githubRepoAutocomplete.innerHTML = '<div class="autocomplete-loading">🔍 Searching GitHub...</div>';
+        githubRepoAutocomplete.classList.remove('hidden');
+
+        // Debounce the search request with longer delay for better UX
         autocompleteTimeout = setTimeout(async () => {
             try {
                 const response = await fetch(`/api/github/search?q=${encodeURIComponent(query)}`);
@@ -80,14 +86,16 @@ document.addEventListener('DOMContentLoaded', function() {
                 displayAutocompleteResults(data.repositories || []);
             } catch (error) {
                 console.error('Error fetching autocomplete results:', error);
-                githubRepoAutocomplete.classList.add('hidden');
+                githubRepoAutocomplete.innerHTML = '<div class="autocomplete-error">❌ Failed to load results</div>';
+            } finally {
+                isSearching = false;
             }
-        }, 300); // Wait 300ms after user stops typing
+        }, 500); // Wait 500ms after user stops typing for better UX
     }
 
     function displayAutocompleteResults(repositories) {
         if (repositories.length === 0) {
-            githubRepoAutocomplete.classList.add('hidden');
+            githubRepoAutocomplete.innerHTML = '<div class="autocomplete-no-results">🔍 No repositories found</div>';
             return;
         }
 

--- a/sweagent/api/static/style.css
+++ b/sweagent/api/static/style.css
@@ -666,6 +666,25 @@ header h1 {
     gap: 4px;
 }
 
+.autocomplete-loading, .autocomplete-error, .autocomplete-no-results {
+    padding: 12px 16px;
+    text-align: center;
+    color: #666;
+    font-size: 0.9em;
+}
+
+.autocomplete-loading {
+    color: #667eea;
+}
+
+.autocomplete-error {
+    color: #e74c3c;
+}
+
+.autocomplete-no-results {
+    color: #999;
+}
+
 .run-info {
     display: flex;
     gap: 15px;


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#13](https://github.com/gatepoet/SWE-agent-web/issues/13) (Github repo search buggy).

Closes #13.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
I'll start by exploring the repository structure to understand the codebase and locate the GitHub search functionality mentioned in the PR description.
**👀‍ Observation (0)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web, excluding hidden items:
/gatepoet__SWE-agent-web
/gatepoet__SWE-agent-web/mkdocs.yml
/gatepoet__SWE-agent-web/codecov.yml
/gatepoet__SWE-agent-web/config
/gatepoet__SWE-agent-web/config/demo
/gatepoet__SWE-agent-web/config/exotic
/gatepoet__SWE-agent-web/config/coding_challenge.yaml
/gatepoet__SWE-agent-web/config/default.yaml
/gatepoet__SWE-agent-web/config/default_mm_no_images.yaml
/gatepoet__SWE-agent-web/config/default_mm_with_images.yaml
/gatepoet__SWE-agent-web/config/bash_only.yaml
/gatepoet__SWE-agent-web/config/api_default.yaml
/gatepoet__SWE-agent-web/config/human
/gatepoet__SWE-agent-web/config/default_backticks.yaml
/gatepoet__SWE-agent-web/config/benchmarks
/gatepoet__SWE-agent-web/config/README.md
/gatepoet__SWE-agent-web/config/sweagent_0_7
/gatepoet__SWE-agent-web/models.json
/gatepoet__SWE-agent-web/tests
/gatepoet__SWE-agent-web/tests/test_run_hooks.py
/gatepoet__SWE-agent-web/tests/test_problem_statement_multimodal.py
/gatepoet__SWE-agent-web/tests/test_data
/gatepoet__SWE-agent-web/tests/__init__.py
/gatepoet__SWE-agent-web/tests/test_tools_command_parsing.py
/gatepoet__SWE-agent-web/tests/test_parsing.py
/gatepoet__SWE-agent-web/tests/test_run_replay.py
/gatepoet__SWE-agent-web/tests/test_run.py
/gatepoet__SWE-agent-web/tests/test_models.py
/gatepoet__SWE-agent-web/tests/test_commands
/gatepoet__SWE-agent-web/tests/utils.py
/gatepoet__SWE-agent-web/tests/test_utils.py
/gatepoet__SWE-agent-web/tests/test_history_processors.py
/gatepoet__SWE-agent-web/tests/test_quick_stats.py
/gatepoet__SWE-agent-web/tests/conftest.py
/gatepoet__SWE-agent-web/tests/test_env.py
/gatepoet__SWE-agent-web/tests/test_run_batch.py
/gatepoet__SWE-agent-web/tests/test_run_single.py
/gatepoet__SWE-agent-web/tests/test_batch_instance.py
/gatepoet__SWE-agent-web/tests/tools
/gatepoet__SWE-agent-web/tests/test_packaging.py
/gatepoet__SWE-agent-web/tests/test_env_utils.py
/gatepoet__SWE-agent-web/tests/test_agent.py
/gatepoet__SWE-agent-web/mlc_config.json
/gatepoet__SWE-agent-web/pyproject.toml
/gatepoet__SWE-agent-web/docs
/gatepoet__SWE-agent-web/docs/installation
/gatepoet__SWE-agent-web/docs/config
/gatepoet__SWE-agent-web/docs/usage
/gatepoet__SWE-agent-web/docs/_footer.md
/gatepoet__SWE-agent-web/docs/faq.md
/gatepoet__SWE-agent-web/docs/dev
/gatepoet__SWE-agent-web/docs/background
/gatepoet__SWE-agent-web/docs/index.md
/gatepoet__SWE-agent-web/docs/CNAME
/gatepoet__SWE-agent-web/docs/overrides
/gatepoet__SWE-agent-web/docs/assets
/gatepoet__SWE-agent-web/docs/README.md
/gatepoet__SWE-agent-web/docs/reference
/gatepoet__SWE-agent-web/CONTRIBUTING.md
/gatepoet__SWE-agent-web/assets
/gatepoet__SWE-agent-web/assets/swe-agent-banner.svg
/gatepoet__SWE-agent-web/assets/swe-agent-banner-light.svg
/gatepoet__SWE-agent-web/assets/swe-agent-banner.png
/gatepoet__SWE-agent-web/assets/swe-agent-banner-dark.svg
/gatepoet__SWE-agent-web/assets/swe-agent-hand.svg
/gatepoet__SWE-agent-web/assets/swe-agent-hand.png
/gatepoet__SWE-agent-web/assets/batch_animated.gif
/gatepoet__SWE-agent-web/sweagent
/gatepoet__SWE-agent-web/sweagent/__main__.py
/gatepoet__SWE-agent-web/sweagent/__init__.py
/gatepoet__SWE-agent-web/sweagent/api
/gatepoet__SWE-agent-web/sweagent/run
/gatepoet__SWE-agent-web/sweagent/inspector
/gatepoet__SWE-agent-web/sweagent/utils
/gatepoet__SWE-agent-web/sweagent/types.py
/gatepoet__SWE-agent-web/sweagent/agent
/gatepoet__SWE-agent-web/sweagent/exceptions.py
/gatepoet__SWE-agent-web/sweagent/tools
/gatepoet__SWE-agent-web/sweagent/environment
/gatepoet__SWE-agent-web/README.md
/gatepoet__SWE-agent-web/SECURITY.md
/gatepoet__SWE-agent-web/tools
/gatepoet__SWE-agent-web/tools/filemap
/gatepoet__SWE-agent-web/tools/windowed_edit_linting
/gatepoet__SWE-agent-web/tools/windowed
/gatepoet__SWE-agent-web/tools/edit_anthropic
/gatepoet__SWE-agent-web/tools/search
/gatepoet__SWE-agent-web/tools/web_browser
/gatepoet__SWE-agent-web/tools/forfeit
/gatepoet__SWE-agent-web/tools/windowed_edit_replace
/gatepoet__SWE-agent-web/tools/review_on_submit_m
/gatepoet__SWE-agent-web/tools/multilingual_setup
/gatepoet__SWE-agent-web/tools/diff_state
/gatepoet__SWE-agent-web/tools/registry
/gatepoet__SWE-agent-web/tools/image_tools
/gatepoet__SWE-agent-web/tools/windowed_edit_rewrite
/gatepoet__SWE-agent-web/tools/submit
/gatepoet__SWE-agent-web/LICENSE
/gatepoet__SWE-agent-web/sweagent.egg-info
/gatepoet__SWE-agent-web/sweagent.egg-info/entry_points.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/dependency_links.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/PKG-INFO
/gatepoet__SWE-agent-web/sweagent.egg-info/top_level.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/requires.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/SOURCES.txt
/gatepoet__SWE-agent-web/trajectories
/gatepoet__SWE-agent-web/trajectories/README.md
/gatepoet__SWE-agent-web/trajectories/demonstrations
```

---

**🧑‍🚒 Response (1)**: 
Let me look at the API server code since that's where the GitHub search functionality is likely implemented:
**👀‍ Observation (1)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/sweagent/api, excluding hidden items:
/gatepoet__SWE-agent-web/sweagent/api
/gatepoet__SWE-agent-web/sweagent/api/__init__.py
/gatepoet__SWE-agent-web/sweagent/api/websocket_hook.py
/gatepoet__SWE-agent-web/sweagent/api/server.py
/gatepoet__SWE-agent-web/sweagent/api/static
/gatepoet__SWE-agent-web/sweagent/api/static/app.js
/gatepoet__SWE-agent-web/sweagent/api/static/index.html
/gatepoet__SWE-agent-web/sweagent/api/static/style.css
/gatepoet__SWE-agent-web/sweagent/api/static/js-yaml.min.js
/gatepoet__SWE-agent-web/sweagent/api/README.md
```

---

**🧑‍🚒 Response (2)**: 
Let me check the server.py file to understand the API structure:
**👀‍ Observation (2)**:
```
<NOTE>This file is too large to display entirely. Showing abbreviated version. Please use `str_replace_editor view` with the `view_range` parameter to show selected lines next.</NOTE>
     1 """Flask API server for SWE-agent web interface."""
     2 
     3 from __future__ import annotations
     4 
     5 import argparse
     6 import asyncio
     7 import json
     8 import logging
     9 import os
    10 import signal
    11 import sys
    12 import threading
    13 import time
    14 from pathlib import Path
    15 from typing import Any, Dict, List, Optional, Tuple
    16 
    17 import yaml
    18 from flask import Flask, jsonify, request, send_from_directory
    19 from flask_cors import CORS
    20 from flask_socketio import SocketIO
    21 
    22 # Import SWE-agent components
    23 from sweagent.api.websocket_hook import WebSocketHook
    24 from sweagent.run.run_single import RunSingleConfig
    25 from sweagent.types import AgentRunResult
    26 
    27 
    28 logging.basicConfig(level=logging.INFO)
    29 logger = logging.getLogger(__name__)
    30 
    31 app = Flask(__name__, static_folder="static", static_url_path="/static")
    32 CORS(app)
    33 socketio = SocketIO(app, cors_allowed_origins="*")
    34 
    35 
    36 def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    37 ... eliding lines 37-73 ...
    74 
    75 # Global state for active runs
    76 active_runs: Dict[str, Any] = {}
    77 runs_lock = threading.Lock()
    78 
    79 
    80 class RunState:
    81     """Track the state of a running SWE-agent instance."""
    82     
    83     def __init__(self, run_id: str):
    84 ... eliding lines 84-93 ...
    94     
    95     def to_dict(self):
    96         # Get current step info if available
    97 ... eliding lines 97-119 ...
   120 
   121 
   122 def get_run_state(run_id: str) -> Optional[RunState]:
   123     """Get run state by ID."""
   124     with runs_lock:
   125         return active_runs.get(run_id)
   126 
   127 def set_run_state(run_id: str, state: RunState):
   128     """Set run state by ID."""
   129     with runs_lock:
   130         active_runs[run_id] = state
   131 
   132 def remove_run_state(run_id: str):
   133     """Remove run state by ID."""
   134     with runs_lock:
   135         if run_id in active_runs:
   136             del active_runs[run_id]
   137 
   138 def generate_run_id() -> str:
   139     """Generate a unique run ID."""
   140     return f"run_{int(time.time() * 1000)}"
   141 
   142 
   143 def _run_single_with_result(config: RunSingleConfig, websocket_hook: Optional[WebSocketHook] = None) -> AgentRunResult:
   144 ... eliding lines 144-158 ...
   159 
   160 
   161 
   162 @app.route("/api/runs", methods=["GET"])
   163 def list_runs():
   164     """List all active and completed runs."""
   165     with runs_lock:
   166         runs = [state.to_dict() for state in active_runs.values()]
   167     return jsonify({"runs": runs})
   168 
   169 
   170 @app.route("/api/runs/<run_id>", methods=["GET"])
   171 def get_run(run_id: str):
   172 ... eliding lines 172-177 ...
   178 
   179 
   180 @app.route("/api/runs/<run_id>/trajectory", methods=["GET"])
   181 def get_trajectory(run_id: str):
   182 ... eliding lines 182-201 ...
   202 
   203 
   204 def emit_update(run_id: str, event: str, data: Any):
   205     """Emit an update to all connected clients for a run."""
   206     socketio.emit(f"run_{run_id}_{event}", data)
   207     socketio.emit("update", {"run_id": run_id, **data})
   208 
   209 
   210 def deep_merge(dict1: Dict[str, Any], dict2: Dict[str, Any]) -> Dict[str, Any]:
   211 ... eliding lines 211-220 ...
   221 
   222 
   223 def create_agent_config(problem_statement: str, config_path: Optional[str] = None, inline_config: Optional[Dict[str, Any]] = None) -> RunSingleConfig:
   224 ... eliding lines 224-253 ...
   254 
   255 
   256 async def run_agent_async(run_id: str, problem_statement: str, config_path: Optional[str] = None, inline_config: Optional[Dict[str, Any]] = None):
   257 ... eliding lines 257-313 ...
   314 
   315 
   316 @app.route("/api/runs", methods=["POST"])
   317 def create_run():
   318 ... eliding lines 318-358 ...
   344 ... eliding lines 344-349 ...
   359 
   360 
   361 @app.route("/api/models", methods=["GET"])
   362 def get_models():
   363 ... eliding lines 363-389 ...
   390 
   391 
   392 @app.route("/api/github/search", methods=["GET", "POST"])
   393 def search_github_repositories():
   394 ... eliding lines 394-427 ...
   428 
   429 
   430 @app.route("/api/status", methods=["GET"])
   431 def get_status():
   432 ... eliding lines 432-437 ...
   438 
   439 
   440 @app.route("/api/config/schema", methods=["GET"])
   441 def get_config_schema():
   442 ... eliding lines 442-471 ...
   472 
   473 
   474 @app.route("/", methods=["GET"])
   475 def serve_index():
   476     """Serve the main HTML page."""
   477     return send_from_directory(app.static_folder, "index.html")
   478 
   479 
   480 @socketio.on("connect")
   481 def handle_connect():
   482     """Handle client connection."""
   483     logger.info("Client connected")
   484 
   485 
   486 @socketio.on("disconnect")
   487 def handle_disconnect():
   488     """Handle client disconnection."""
   489     logger.info("Client disconnected")
   490 
   491 
   492 def get_parser() -> argparse.ArgumentParser:
   493 ... eliding lines 493-498 ...
   499 
   500 
   501 async def main(args: Optional[List[str]] = None):
   502 ... eliding lines 502-521 ...
   522 
   523 
   524 if __name__ == "__main__":
   525     asyncio.run(main())
<IMPORTANT><NOTE>The above file has been abbreviated. Please use `str_replace editor view` with `view_range` to look at relevant files in detail.</NOTE></IMPORTANT>
```

---

**🧑‍🚒 Response (3)**: 
Let me look at the GitHub search function specifically:
**👀‍ Observation (3)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/server.py:
    36	def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    37	    """Search for GitHub repositories using the GitHub API."""
    38	    import requests
    39	    
    40	    # Check if we have a GitHub token in environment variables
    41	    github_token = os.getenv("GITHUB_TOKEN", "")
    42	    headers = {}
    43	    if github_token:
    44	        headers["Authorization"] = f"token {github_token}"
    45	    
    46	    # Build search URL
    47	    search_url = f"https://api.github.com/search/repositories?q={query}&per_page={max_results}"
    48	    
    49	    try:
    50	        response = requests.get(search_url, headers=headers, timeout=10)
    51	        response.raise_for_status()
    52	        
    53	        data = response.json()
    54	        repositories = []
    55	        
    56	        for repo in data.get("items", []):
    57	            repo_info = {
    58	                "full_name": repo.get("full_name", ""),
    59	                "name": repo.get("name", ""),
    60	                "owner": repo.get("owner", {}).get("login", ""),
    61	                "html_url": repo.get("html_url", ""),
    62	                "description": repo.get("description", ""),
    63	                "stargazers_count": repo.get("stargazers_count", 0),
    64	                "forks_count": repo.get("forks_count", 0),
    65	            }
    66	            repositories.append(repo_info)
    67	        
    68	        return repositories
    69	        
    70	    except requests.exceptions.RequestException as e:
    71	        logger.error(f"GitHub API request failed: {e}")
    72	        # Return empty results on error
    73	        return []
    74
```

---

**🧑‍🚒 Response (4)**: 
Now let me look at the GitHub search endpoint:
**👀‍ Observation (4)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/server.py:
   392	@app.route("/api/github/search", methods=["GET", "POST"])
   393	def search_github_repositories():
   394	    """Search for GitHub repositories by name or query."""
   395	    try:
   396	        # Get search query from either GET params or POST body
   397	        if request.method == "GET":
   398	            query = request.args.get('q', '')
   399	        else:  # POST
   400	            # Try JSON first, then form data
   401	            json_data = request.get_json(silent=True)
   402	            if json_data and 'q' in json_data:
   403	                query = json_data['q']
   404	            elif request.form and 'q' in request.form:
   405	                query = request.form['q']
   406	            else:
   407	                query = ''
   408	        
   409	        if not query:
   410	            return jsonify({
   411	                "error": "Search query 'q' is required",
   412	                "repositories": []
   413	            }), 400
   414	        
   415	        # Use GitHub API to search for repositories
   416	        results = search_github_repos(query)
   417	        
   418	        return jsonify({
   419	            "query": query,
   420	            "repositories": results
   421	        })
   422	    except Exception as e:
   423	        logger.error(f"Error searching GitHub repositories: {e}")
   424	        return jsonify({
   425	            "error": str(e),
   426	            "repositories": []
   427	        }), 500
   428
```

---

**🧑‍🚒 Response (5)**: 
Now let me check the frontend JavaScript to see how the search is implemented:
**👀‍ Observation (5)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/static/app.js:
     1	// Connect to Socket.IO server
     2	document.addEventListener('DOMContentLoaded', function() {
     3	    const socket = io();
     4	    
     5	    // DOM elements
     6	    const problemStatementInput = document.getElementById('problemStatement');
     7	    const startRunButton = document.getElementById('startRun');
     8	    const activeRunsContainer = document.getElementById('activeRuns');
     9	    const chatMessagesContainer = document.getElementById('chatMessages');
    10	    const timelineViewContainer = document.getElementById('timelineView');
    11	    const runDetailsContainer = document.getElementById('runDetails');
    12	    const runStatusElement = document.getElementById('runStatus');
    13	    const exitStatusElement = document.getElementById('exitStatus');
    14	    const stepCountElement = document.getElementById('stepCount');
    15	    
    16	    // Problem statement type radio buttons
    17	    const textProblemTypeRadio = document.getElementById('textProblemType');
    18	    const githubProblemTypeRadio = document.getElementById('githubProblemType');
    19	    const inputHint = document.getElementById('inputHint');
    20	    const githubHint = document.getElementById('githubHint');
    21	    
    22	    // Cost display elements
    23	    const costDisplayContainer = document.getElementById('costDisplay');
    24	    const costStatsContainer = document.getElementById('costStats');
    25	    
    26	    // Repository configuration elements
    27	    const repoTypeSelect = document.getElementById('repoType');
    28	    const repoPathGroup = document.getElementById('repoPathGroup');
    29	    const githubRepoGroup = document.getElementById('githubRepoGroup');
    30	    const repoPathInput = document.getElementById('repoPath');
    31	    const githubRepoUrlInput = document.getElementById('githubRepoUrl');
    32	    const githubRepoAutocomplete = document.getElementById('githubRepoAutocomplete');
    33	    
    34	    // Config file upload elements
    35	    const configFileInput = document.getElementById('configFile');
    36	    const fileNameDisplay = document.getElementById('fileName');
    37	    
    38	    // Model selection element
    39	    const modelSelect = document.getElementById('modelName');
    40	    
    41	    let currentRunId = null;
    42	    
    43	    // Handle repository type selection
    44	    repoTypeSelect.addEventListener('change', function() {
    45	        const repoType = this.value;
    46	        if (repoType === 'local') {
    47	            repoPathGroup.style.display = 'block';
    48	            githubRepoGroup.style.display = 'none';
    49	        } else if (repoType === 'github') {
    50	            repoPathGroup.style.display = 'none';
    51	            githubRepoGroup.style.display = 'block';
    52	        } else {
    53	            repoPathGroup.style.display = 'none';
    54	            githubRepoGroup.style.display = 'none';
    55	        }
    56	    });
    57	
    58	    // GitHub repository autocomplete functionality
    59	    let autocompleteTimeout = null;
    60	    let selectedAutocompleteIndex = -1;
    61	
    62	    function showGitHubAutocomplete(query) {
    63	        if (query.length < 2) {
    64	            githubRepoAutocomplete.classList.add('hidden');
    65	            return;
    66	        }
    67	
    68	        // Clear previous timeout
    69	        if (autocompleteTimeout) {
    70	            clearTimeout(autocompleteTimeout);
    71	        }
    72	
    73	        // Debounce the search request
    74	        autocompleteTimeout = setTimeout(async () => {
    75	            try {
    76	                const response = await fetch(`/api/github/search?q=${encodeURIComponent(query)}`);
    77	                if (!response.ok) throw new Error('Search failed');
    78	                
    79	                const data = await response.json();
    80	                displayAutocompleteResults(data.repositories || []);
    81	            } catch (error) {
    82	                console.error('Error fetching autocomplete results:', error);
    83	                githubRepoAutocomplete.classList.add('hidden');
    84	            }
    85	        }, 300); // Wait 300ms after user stops typing
    86	    }
    87	
    88	    function displayAutocompleteResults(repositories) {
    89	        if (repositories.length === 0) {
    90	            githubRepoAutocomplete.classList.add('hidden');
    91	            return;
    92	        }
    93	
    94	        let html = '';
    95	        repositories.forEach((repo, index) => {
    96	            const fullName = repo.full_name || `${repo.owner}/${repo.name}`;
    97	            html += `
    98	                <div class="autocomplete-item" data-index="${index}">
    99	                    <span class="autocomplete-repo-icon">🐙</span>
   100	                    <div class="autocomplete-repo-info">
   101	                        <div class="autocomplete-repo-name">${repo.name || 'Unknown'}</div>
   102	                        <div class="autocomplete-repo-fullname">${fullName}</div>
   103	                        ${repo.description ? `<div class="autocomplete-repo-description">${repo.description}</div>` : ''}
   104	                        <div class="autocomplete-repo-stats">
   105	                            <span class="autocomplete-repo-stat">⭐ ${repo.stargazers_count || 0}</span>
   106	                            <span class="autocomplete-repo-stat">🍴 ${repo.forks_count || 0}</span>
   107	                        </div>
   108	                    </div>
   109	                </div>`;
   110	        });
   111	
   112	        githubRepoAutocomplete.innerHTML = html;
   113	        githubRepoAutocomplete.classList.remove('hidden');
   114	    }
   115	
   116	    function selectAutocompleteItem(index) {
   117	        const items = githubRepoAutocomplete.querySelectorAll('.autocomplete-item');
   118	        if (index >= 0 && index < items.length) {
   119	            // Remove active class from all items
   120	            items.forEach(item => item.classList.remove('active'));
   121	            // Add active class to selected item
   122	            items[index].classList.add('active');
   123	            return true;
   124	        }
   125	        return false;
   126	    }
   127	
   128	    function useSelectedAutocompleteItem() {
   129	        const activeItem = githubRepoAutocomplete.querySelector('.autocomplete-item.active');
   130	        if (activeItem) {
   131	            const index = parseInt(activeItem.dataset.index);
   132	            const items = Array.from(githubRepoAutocomplete.querySelectorAll('.autocomplete-item'));
   133	            const selectedRepo = items[index];
   134	            
   135	            // Extract the full GitHub URL
   136	            const repoInfo = selectedRepo.querySelector('.autocomplete-repo-info');
   137	            const fullNameElement = repoInfo.querySelector('.autocomplete-repo-fullname');
   138	            const fullName = fullNameElement.textContent;
   139	            
   140	            githubRepoUrlInput.value = `https://github.com/${fullName}`;
   141	            githubRepoAutocomplete.classList.add('hidden');
   142	            return true;
   143	        }
   144	        return false;
   145	    }
   146	    
   147	    // Handle problem statement type selection
   148	    textProblemTypeRadio.addEventListener('change', function() {
   149	        if (this.checked) {
   150	            inputHint.classList.remove('hidden');
   151	            githubHint.classList.add('hidden');
   152	            problemStatementInput.placeholder = "Enter your problem statement here...";
   153	        }
   154	    });
   155	    
   156	    githubProblemTypeRadio.addEventListener('change', function() {
   157	        if (this.checked) {
   158	            inputHint.classList.add('hidden');
   159	            githubHint.classList.remove('hidden');
   160	            problemStatementInput.placeholder = "Enter GitHub issue URL: https://github.com/owner/repo/issues/123";
   161	        }
   162	    });
   163	
   164	    // Add event listeners for GitHub repository autocomplete
   165	    githubRepoUrlInput.addEventListener('input', function(e) {
   166	        const query = e.target.value.trim();
   167	        showGitHubAutocomplete(query);
   168	    });
   169	
   170	    githubRepoUrlInput.addEventListener('keydown', function(e) {
   171	        const items = githubRepoAutocomplete.querySelectorAll('.autocomplete-item');
   172	        
   173	        if (!githubRepoAutocomplete.classList.contains('hidden') && items.length > 0) {
   174	            // Handle arrow key navigation
   175	            if (e.key === 'ArrowDown') {
   176	                e.preventDefault();
   177	                selectedAutocompleteIndex = Math.min(selectedAutocompleteIndex + 1, items.length - 1);
   178	                selectAutocompleteItem(selectedAutocompleteIndex);
   179	            } else if (e.key === 'ArrowUp') {
   180	                e.preventDefault();
   181	                selectedAutocompleteIndex = Math.max(selectedAutocompleteIndex - 1, 0);
   182	                selectAutocompleteItem(selectedAutocompleteIndex);
   183	            } else if (e.key === 'Enter') {
   184	                e.preventDefault();
   185	                if (useSelectedAutocompleteItem()) {
   186	                    return;
   187	                }
   188	            }
   189	        }
   190	    });
   191	
   192	    githubRepoUrlInput.addEventListener('blur', function() {
   193	        // Hide autocomplete when input loses focus
   194	        setTimeout(() => {
   195	            githubRepoAutocomplete.classList.add('hidden');
   196	            selectedAutocompleteIndex = -1;
   197	        }, 200);
   198	    });
   199	    
   200	    // Handle config file upload
   201	    configFileInput.addEventListener('change', function(e) {
   202	        if (e.target.files.length > 0) {
   203	            const file = e.target.files[0];
   204	            fileNameDisplay.textContent = file.name;
   205	            
   206	            // Validate file type
   207	            if (!file.name.endsWith('.yaml') && !file.name.endsWith('.yml')) {
   208	                alert('Please upload a YAML file (.yaml or .yml)');
   209	                configFileInput.value = ''; // Clear the input
   210	                fileNameDisplay.textContent = 'No file chosen';
   211	            }
   212	        } else {
   213	            fileNameDisplay.textContent = 'No file chosen';
   214	        }
   215	    });
   216	    
   217	    // Add step to timeline view
   218	    function addStepToTimeline(stepNum, stepData) {
   219	        const stepCard = document.createElement('div');
   220	        stepCard.className = 'step-card';
   221	        
   222	        let thoughtContent = '';
   223	        let actionContent = '';
   224	        let observationContent = '';
   225	        let responseContent = '';
   226	        
   227	        if (stepData.thought) {
   228	            thoughtContent = formatComponent('Thought', stepData.thought, 'thought');
   229	        }
   230	        
   231	        if (stepData.action) {
   232	            // Check if action is a bash command
   233	            const bashRegex = /^bash: (.+)$/i;
   234	            if (bashRegex.test(stepData.action)) {
   235	                const bashCommand = stepData.action.replace(bashRegex, '$1');
   236	                actionContent = formatComponent('Action', `<pre>${escapeHtml(bashCommand)}</pre>`, 'action');
   237	            } else {
   238	                actionContent = formatComponent('Action', escapeHtml(stepData.action), 'action');
   239	            }
   240	        }
   241	        
   242	        if (stepData.observation) {
   243	            observationContent = formatComponent('Observation', escapeHtml(stepData.observation), 'observation');
   244	        }
   245	        
   246	        if (stepData.response && stepData.response.trim() !== '') {
   247	            // Check if response looks like code
   248	            const lines = stepData.response.split('\n');
   249	            if (lines.length > 1 || stepData.response.includes('\t') || stepData.response.match(/^[a-zA-Z0-9_]+:/)) {
   250	                responseContent = formatComponent('Response', `<pre>${escapeHtml(stepData.response)}</pre>`, 'response');
   251	            } else {
   252	                responseContent = formatComponent('Response', escapeHtml(stepData.response), 'response');
   253	            }
   254	        }
   255	        
   256	        stepCard.innerHTML = `
   257	            <div class="step-header">
   258	                <span class="step-number">Step ${stepNum}</span>
   259	                <span class="step-icon">▼</span>
   260	            </div>
   261	            <div class="step-content">
   262	                <div class="step-details">
   263	                    ${thoughtContent}
   264	                    ${actionContent}
   265	                    ${observationContent}
   266	                    ${responseContent}
   267	                </div>
   268	            </div>`;
   269	        
   270	        // Add click handler for accordion
   271	        stepCard.addEventListener('click', function(e) {
   272	            // Don't toggle if clicking on a copy button or link
   273	            if (e.target.tagName === 'BUTTON' || e.target.tagName === 'A') {
   274	                return;
   275	            }
   276	            
   277	            stepCard.classList.toggle('active');
   278	        });
   279	        
   280	        timelineViewContainer.appendChild(stepCard);
   281	    }
   282	    
   283	    // Format a component (thought, action, observation, response) with proper styling
   284	    function formatComponent(label, content, type) {
   285	        const className = `${type}-section component-section`;
   286	        return `<div class="${className}"><span class="component-label">${label}</span><div class="component-content">${content}</div></div>`;
   287	    }
   288	    
   289	    // Update cost display with model stats
   290	    function updateCostDisplay(stats) {
   291	        let html = '';
   292	        
   293	        // Format stat key for display
   294	        const formatStatKey = (key) => {
   295	            const mappings = {
   296	                'total_tokens': 'Total Tokens',
   297	                'input_tokens': 'Input Tokens',
   298	                'output_tokens': 'Output Tokens',
   299	                'cost_usd': 'Cost ($)',
   300	                'execution_time': 'Time (s)'
   301	            };
   302	            return mappings[key] || key.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
   303	        };
   304	        
   305	        // Display all stats except cost
   306	        Object.entries(stats).forEach(([key, value]) => {
   307	            if (key !== 'cost_usd') {
   308	                const formattedValue = typeof value === 'number' ? value.toFixed(2) : value;
   309	                html += `<div class="cost-stat"><span class="cost-label">${formatStatKey(key)}:</span><span class="cost-value">${formattedValue}</span></div>`;
   310	            }
   311	        });
   312	        
   313	        // Display cost separately with emphasis
   314	        if (stats.cost_usd !== undefined) {
   315	            const costValue = typeof stats.cost_usd === 'number' ? stats.cost_usd.toFixed(2) : stats.cost_usd;
   316	            html += `<div class="cost-stat cost-total"><span class="cost-label">Total Cost:</span><span class="cost-value">$${costValue}</span></div>`;
   317	        }
   318	        
   319	        costStatsContainer.innerHTML = html;
   320	    }
   321	    
   322	    // Add message to chat
   323	    function addChatMessage(role, content) {
   324	        const messageDiv = document.createElement('div');
   325	        messageDiv.className = `chat-message message-${role}`;
   326	        
   327	        // Check if content contains code (bash commands or file content)
   328	        let formattedContent = content;
   329	        
   330	        // Detect bash commands
   331	        const bashRegex = /^bash: (.+)$/i;
   332	        const bashMatch = content.match(bashRegex);
   333	        
   334	        if (bashMatch) {
   335	            // Format as code block with copy button
   336	            formattedContent = `
   337	                <div class="message-content">
   338	                    <div class="code-header">
   339	                        <span class="code-language">Bash</span>
   340	                        <button class="copy-button" onclick="copyToClipboard('${encodeHTML(bashMatch[1])}')">Copy</button>
   341	                    </div>
   342	                    <pre class="code-block"><code>${escapeHtml(bashMatch[1])}</code></pre>
   343	                </div>`;
   344	        } else if (content.includes('\n')) {
   345	            // Multi-line content - format as preformatted
   346	            formattedContent = `
   347	                <div class="message-content">
   348	                    <pre>${escapeHtml(content)}</pre>
   349	                </div>`;
   350	        }
   351	        
   352	        messageDiv.innerHTML = `<strong>${role}:</strong> ${formattedContent}`;
   353	        chatMessagesContainer.appendChild(messageDiv);
   354	        chatMessagesContainer.scrollTop = chatMessagesContainer.scrollHeight;
   355	    }
   356	    
   357	    // Add collapsible code block
   358	    function addCodeBlock(role, language, content) {
   359	        const messageDiv = document.createElement('div');
   360	        messageDiv.className = `chat-message message-${role}`;
   361	        
   362	        messageDiv.innerHTML = `
   363	            <strong>${role}:</strong>
   364	            <div class="message-content">
   365	                <details class="code-details">
   366	                    <summary class="code-summary">
   367	                        <span class="code-language">${language}</span>
   368	                        <button class="copy-button" onclick="copyToClipboard('${encodeHTML(content)}')">Copy</button>
   369	                    </summary>
   370	                    <pre class="code-block"><code>${escapeHtml(content)}</code></pre>
   371	                </details>
   372	            </div>`;
   373	        
   374	        chatMessagesContainer.ap<response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>
```

---

**🧑‍🚒 Response (6)**: 
Let me search for more specific GitHub-related code:
**👀‍ Observation (6)**:
```
18:    const githubProblemTypeRadio = document.getElementById('githubProblemType');
20:    const githubHint = document.getElementById('githubHint');
29:    const githubRepoGroup = document.getElementById('githubRepoGroup');
31:    const githubRepoUrlInput = document.getElementById('githubRepoUrl');
32:    const githubRepoAutocomplete = document.getElementById('githubRepoAutocomplete');
48:            githubRepoGroup.style.display = 'none';
49:        } else if (repoType === 'github') {
51:            githubRepoGroup.style.display = 'block';
54:            githubRepoGroup.style.display = 'none';
64:            githubRepoAutocomplete.classList.add('hidden');
76:                const response = await fetch(`/api/github/search?q=${encodeURIComponent(query)}`);
83:                githubRepoAutocomplete.classList.add('hidden');
90:            githubRepoAutocomplete.classList.add('hidden');
112:        githubRepoAutocomplete.innerHTML = html;
113:        githubRepoAutocomplete.classList.remove('hidden');
117:        const items = githubRepoAutocomplete.querySelectorAll('.autocomplete-item');
129:        const activeItem = githubRepoAutocomplete.querySelector('.autocomplete-item.active');
132:            const items = Array.from(githubRepoAutocomplete.querySelectorAll('.autocomplete-item'));
140:            githubRepoUrlInput.value = `https://github.com/${fullName}`;
141:            githubRepoAutocomplete.classList.add('hidden');
151:            githubHint.classList.add('hidden');
156:    githubProblemTypeRadio.addEventListener('change', function() {
159:            githubHint.classList.remove('hidden');
160:            problemStatementInput.placeholder = "Enter GitHub issue URL: https://github.com/owner/repo/issues/123";
165:    githubRepoUrlInput.addEventListener('input', function(e) {
170:    githubRepoUrlInput.addEventListener('keydown', function(e) {
171:        const items = githubRepoAutocomplete.querySelectorAll('.autocomplete-item');
173:        if (!githubRepoAutocomplete.classList.contains('hidden') && items.length > 0) {
192:    githubRepoUrlInput.addEventListener('blur', function() {
195:            githubRepoAutocomplete.classList.add('hidden');
601:        } else if (repoType === 'github' && githubRepoUrlInput.value) {
604:            config.env.repo.type = 'github';
605:            config.env.repo.github_url = githubRepoUrlInput.value;
612:        if (problemType === 'github') {
615:                type: 'github',
616:                github_url: problemStatement
```

---

**🧑‍🚒 Response (7)**: 
Now let me look at the HTML to understand the UI structure better:
**👀‍ Observation (7)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/static/index.html:
     1	<!DOCTYPE html>
     2	<html lang="en">
     3	<head>
     4	    <meta charset="UTF-8">
     5	    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     6	    <title>SWE-agent Chatbot Interface</title>
     7	    <link rel="stylesheet" href="/static/style.css">
     8	    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     9	</head>
    10	<body>
    11	    <div class="container">
    12	        <header>
    13	            <h1>🤖 SWE-agent Chatbot Interface</h1>
    14	            <p class="subtitle">Run software engineering tasks with AI-powered automation</p>
    15	        </header>
    16	        
    17	        <div class="problem-input">
    18	            <!-- Problem Statement Type Selection -->
    19	            <div class="problem-type-selection">
    20	                <label class="radio-label">
    21	                    <input type="radio" name="problem-statement-type" id="textProblemType" value="text" checked>
    22	                    <span class="radio-custom"></span>
    23	                    <span class="radio-text">📝 Text Problem Statement</span>
    24	                </label>
    25	                <label class="radio-label">
    26	                    <input type="radio" name="problem-statement-type" id="githubProblemType" value="github">
    27	                    <span class="radio-custom"></span>
    28	                    <span class="radio-text">🐙 GitHub Issue URL</span>
    29	                </label>
    30	            </div>
    31	            
    32	            <!-- Problem Statement Input - can be text or GitHub issue URL -->
    33	            <textarea id="problemStatement" placeholder="Enter your problem statement here..." rows="6"></textarea>
    34	            <small id="inputHint">💡 Enter a text description of the problem you want to solve</small>
    35	             
    36	            <!-- GitHub-specific hint (shown when GitHub radio is selected) -->
    37	            <small id="githubHint" class="hidden">💡 Enter GitHub issue URL: https://github.com/owner/repo/issues/123</small>
    38	            
    39	            <!-- Repository Configuration -->
    40	            <div class="config-section">
    41	                <summary>📁 Repository Configuration (Optional)</summary>
    42	                <div class="config-options">
    43	                    <div class="config-group">
    44	                        <label for="repoType">Repository Type:</label>
    45	                        <select id="repoType">
    46	                            <option value="none">None (use current directory)</option>
    47	                            <option value="local">Local Path</option>
    48	                            <option value="github">GitHub Repository</option>
    49	                        </select>
    50	                    </div>
    51	                    <div class="config-group" id="repoPathGroup" style="display: none;">
    52	                        <label for="repoPath">Local Repository Path:</label>
    53	                        <input type="text" id="repoPath" placeholder="/path/to/repository">
    54	                    </div>
    55	                    <div class="config-group" id="githubRepoGroup" style="display: none;">
    56	                        <label for="githubRepoUrl">GitHub Repository URL:</label>
    57	                        <input type="text" id="githubRepoUrl" placeholder="https://github.com/owner/repo">
    58	                        <div id="githubRepoAutocomplete" class="autocomplete-results hidden"></div>
    59	                    </div>
    60	                </div>
    61	            </div>
    62	            
    63	            <!-- Advanced Configuration -->
    64	            <details id="configSection" class="config-section">
    65	                <summary>🔧 Advanced Agent Configuration (Optional)</summary>
    66	                <div class="config-options">
    67	                    <div class="config-group">
    68	                        <label for="modelTemperature">Model Temperature:</label>
    69	                        <input type="number" id="modelTemperature" min="0" max="2" step="0.1" placeholder="0.7 (default)">
    70	                        <small>💡 Higher values = more creative, lower values = more focused</small>
    71	                    </div>
    72	                    <div class="config-group">
    73	                        <label for="modelName">Model Name:</label>
    74	                        <select id="modelName">
    75	                            <option value="">Use default model</option>
    76	                            <!-- Model options will be populated by JavaScript -->
    77	                        </select>
    78	                        <small>💡 Select a model from the available options</small>
    79	                    </div>
    80	                    <div class="config-group">
    81	                        <label for="costLimit">Cost Limit ($):</label>
    82	                        <input type="number" id="costLimit" min="0" step="0.1" placeholder="2.0 (default)">
    83	                        <small>💡 Maximum cost per run to prevent unexpected charges</small>
    84	                    </div>
    85	                    <div class="config-group">
    86	                        <label for="enableBash">Enable Bash Tools:</label>
    87	                        <select id="enableBash">
    88	                            <option value="">Use default</option>
    89	                            <option value="true">Yes</option>
    90	                            <option value="false">No</option>
    91	                        </select>
    92	                        <small>💡 Control whether the agent can execute bash commands</small>
    93	                    </div>
    94	                </div>
    95	            </details>
    96	            
    97	            <!-- Config File Upload -->
    98	            <div class="config-section">
    99	                <label for="configFile" class="file-upload-label">
   100	                    📄 Upload Configuration File (YAML)
   101	                    <input type="file" id="configFile" accept=".yaml,.yml" style="display: none;">
   102	                    <span id="fileName">No file chosen</span>
   103	                </label>
   104	                <small>Or <a href="/api/config/schema" target="_blank">view configuration schema</a> for available options</small>
   105	            </div>
   106	            
   107	            <button id="startRun" class="btn-primary">Start SWE-agent</button>
   108	        </div>
   109	        
   110	        <div class="runs-list">
   111	            <h2>Active Runs</h2>
   112	            <div id="activeRuns" class="runs-container"></div>
   113	        </div>
   114	        
   115	        <!-- Cost Display Sidebar - Fixed Placement -->
   116	        <div id="costDisplay" class="cost-display hidden">
   117	            <div class="cost-header">
   118	                <span>💰 Cost</span>
   119	                <span class="cost-icon">$</span>
   120	            </div>
   121	            <div id="costStats"></div>
   122	        </div>
   123	
   124	        <div class="chat-interface">
   125	            <h2>Chat Interface</h2>
   126	            <!-- Timeline View (will replace chat-messages when run is loaded) -->
   127	            <div id="timelineView" class="timeline-container hidden"></div>
   128	            <!-- Fallback Chat Messages View -->
   129	            <div id="chatMessages" class="chat-messages"></div>
   130	            <div id="runDetails" class="run-details hidden">
   131	                <div class="run-info">
   132	                    <span id="runStatus"></span>
   133	                    <span id="exitStatus"></span>
   134	                    <span id="stepCount"></span>
   135	                </div>
   136	            </div>
   137	        </div>
   138	    </div>
   139	    
   140	    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"></script>
   141	    <script src="/static/app.js"></script>
   142	</body>
   143	</html>
   144
```

---

**🧑‍🚒 Response (8)**: 
Now let me check the CSS to understand the styling:
**👀‍ Observation (8)**:
```
601:.autocomplete-results {
613:.autocomplete-item {
622:.autocomplete-item:hover {
626:.autocomplete-item.active {
630:.autocomplete-repo-icon {
635:.autocomplete-repo-info {
639:.autocomplete-repo-name {
645:.autocomplete-repo-fullname {
650:.autocomplete-repo-description {
656:.autocomplete-repo-stats {
663:.autocomplete-repo-stat {
```

---

**🧑‍🚒 Response (9)**: 

**👀‍ Observation (9)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/static/style.css:
   601	.autocomplete-results {
   602	    position: absolute;
   603	    background-color: white;
   604	    border: 2px solid #667eea;
   605	    border-radius: 8px;
   606	    max-height: 300px;
   607	    overflow-y: auto;
   608	    z-index: 1000;
   609	    margin-top: 5px;
   610	    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
   611	}
   612	
   613	.autocomplete-item {
   614	    padding: 12px 16px;
   615	    cursor: pointer;
   616	    transition: background-color 0.3s ease;
   617	    display: flex;
   618	    align-items: center;
   619	    gap: 12px;
   620	}
   621	
   622	.autocomplete-item:hover {
   623	    background-color: #f8f9fa;
   624	}
   625	
   626	.autocomplete-item.active {
   627	    background-color: #e3f2fd;
   628	}
   629	
   630	.autocomplete-repo-icon {
   631	    color: #667eea;
   632	    font-weight: bold;
   633	}
   634	
   635	.autocomplete-repo-info {
   636	    flex: 1;
   637	}
   638	
   639	.autocomplete-repo-name {
   640	    font-weight: 600;
   641	    color: #333;
   642	    margin-bottom: 2px;
   643	}
   644	
   645	.autocomplete-repo-fullname {
   646	    font-size: 0.9em;
   647	    color: #666;
   648	}
   649	
   650	.autocomplete-repo-description {
   651	    font-size: 0.85em;
   652	    color: #999;
   653	    margin-top: 4px;
   654	}
   655	
   656	.autocomplete-repo-stats {
   657	    display: flex;
   658	    gap: 12px;
   659	    font-size: 0.85em;
   660	    color: #666;
   661	}
   662	
   663	.autocomplete-repo-stat {
   664	    display: flex;
   665	    align-items: center;
   666	    gap: 4px;
   667	}
   668	
   669	.run-info {
   670	    display: flex;
```

---

**🧑‍🚒 Response (10)**: 
Now let me analyze the current implementation and understand the issues:

## Analysis of Current GitHub Search Implementation

Based on my examination, I can identify several issues with the current GitHub search functionality:

### Issues Found:

1. **No debouncing/delay mechanism**: The current implementation uses a 300ms timeout but doesn't properly cancel previous requests when new ones come in quickly.

2. **Poor query parsing**: The search function directly passes user input to GitHub API without proper parsing. Users should be able to search by:
   - Username only (e.g., "torvalds")
   - Repository name only (e.g., "react")
   - Full repo path (e.g., "facebook/react")

3. **No caching**: Each keystroke triggers a new API call, even for the same query.

4. **No minimum character requirement**: The frontend shows autocomplete after 2 characters, but this could be optimized.

5. **No error handling in UI**: When GitHub API fails or returns no results, the UI doesn't handle it gracefully.

6. **No loading state**: Users don't know when a search is in progress.

Let me create a test script to understand the current behavior:
**👀‍ Observation (10)**:
```
File created successfully at: /gatepoet__SWE-agent-web/test_github_search.py
```

---

**🧑‍🚒 Response (11)**: 

**👀‍ Observation (11)**:
```
Testing different query formats:

Query: 'torvalds'
Results found: 10
Sample result: mkirchner/linked-list-good-taste

Query: 'react'
Results found: 10
Sample result: facebook/react

Query: 'facebook/react'
Results found: 10
Sample result: facebook/react

Query: 'user:torvalds'
Results found: 6
Sample result: torvalds/linux

Query: 'org:facebook'
Results found: 10
Sample result: facebook/react

Query: 'react in:name'
Results found: 10
Sample result: facebook/react

Query: 'torvalds in:username'
Results found: 10
Sample result: mkirchner/linked-list-good-taste

Testing performance with rapid calls:
Call 1: 10 results, 0.11s elapsed
Call 2: 10 results, 0.32s elapsed
Call 3: 10 results, 0.53s elapsed
Error: 403 Client Error: rate limit exceeded for url: https://api.github.com/search/repositories?q=react&per_page=10
Call 4: 0 results, 0.74s elapsed
Error: 403 Client Error: rate limit exceeded for url: https://api.github.com/search/repositories?q=react&per_page=10
Call 5: 0 results, 0.95s elapsed
Total time for 5 calls: 1.05s
```

---

**🧑‍🚒 Response (12)**: 
Great! This confirms several issues:

1. **Rate limiting**: GitHub API rate limits are hit quickly without authentication
2. **Query parsing**: Different query formats work but need better handling
3. **Performance**: Each call takes ~0.2-0.4 seconds, causing UI lag with rapid typing

Now let me implement a comprehensive fix. I'll start by improving the backend search function:
**👀‍ Observation (12)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/api/server.py:
    36	def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    37	    """Search for GitHub repositories using the GitHub API."""
    38	    import requests
    39	    
    40	    # Check if we have a GitHub token in environment variables
    41	    github_token = os.getenv("GITHUB_TOKEN", "")
    42	    headers = {}
    43	    if github_token:
    44	        headers["Authorization"] = f"token {github_token}"
    45	    
    46	    # Build search URL
    47	    search_url = f"https://api.github.com/search/repositories?q={query}&per_page={max_results}"
    48	    
    49	    try:
    50	        response = requests.get(search_url, headers=headers, timeout=10)
    51	        response.raise_for_status()
    52	        
    53	        data = response.json()
    54	        repositories = []
    55	        
    56	        for repo in data.get("items", []):
    57	            repo_info = {
    58	                "full_name": repo.get("full_name", ""),
    59	                "name": repo.get("name", ""),
    60	                "owner": repo.get("owner", {}).get("login", ""),
    61	                "html_url": repo.get("html_url", ""),
    62	                "description": repo.get("description", ""),
    63	                "stargazers_count": repo.get("stargazers_count", 0),
    64	                "forks_count": repo.get("forks_count", 0),
    65	            }
    66	            repositories.append(repo_info)
    67	        
    68	        return repositories
    69	        
    70	    except requests.exceptions.RequestException as e:
    71	        logger.error(f"GitHub API request failed: {e}")
    72	        # Return empty results on error
    73	        return []
    74
```

---

**🧑‍🚒 Response (13)**: 
Now let me implement the improved GitHub search functionality. I'll create a better version that:

1. Properly parses user queries to handle usernames, repo names, and full paths
2. Implements caching to avoid duplicate API calls
3. Adds proper error handling and rate limit detection
4. Supports different search strategies
**👀‍ Observation (13)**:
```
No replacement was performed, old_str `def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    """Search for GitHub repositories using the GitHub API."""
    import requests
    
    # Check if we have a GitHub token in environment variables
    github_token = os.getenv("GITHUB_TOKEN", "")
    headers = {}
    if github_token:
        headers["Authorization"] = f"token {github_token}"
    
    # Build search URL
    search_url = f"https://api.github.com/search/repositories?q={query}&per_page={max_results}"
    
    try:
        response = requests.get(search_url, headers=headers, timeout=10)
        response.raise_for_status()
        
        data = response.json()
        repositories = []
        
        for repo in data.get("items", []):
            repo_info = {
                "full_name": repo.get("full_name", ""),
                "name": repo.get("name", ""),
                "owner": repo.get("owner", {}).get("login", ""),
                "html_url": repo.get("html_url", ""),
                "description": repo.get("description", ""),
                "stargazers_count": repo.get("stargazers_count", 0),
                "forks_count": repo.get("forks_count", 0),
            }
            repositories.append(repo_info)
        
        return repositories
        
    except requests.exceptions.RequestException as e:
        logger.error(f"GitHub API request failed: {e}")
        # Return empty results on error
        return []` is the same as new_str `def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    """Search for GitHub repositories using the GitHub API."""
    import requests
    
    # Check if we have a GitHub token in environment variables
    github_token = os.getenv("GITHUB_TOKEN", "")
    headers = {}
    if github_token:
        headers["Authorization"] = f"token {github_token}"
    
    # Build search URL
    search_url = f"https://api.github.com/search/repositories?q={query}&per_page={max_results}"
    
    try:
        response = requests.get(search_url, headers=headers, timeout=10)
        response.raise_for_status()
        
        data = response.json()
        repositories = []
        
        for repo in data.get("items", []):
            repo_info = {
                "full_name": repo.get("full_name", ""),
                "name": repo.get("name", ""),
                "owner": repo.get("owner", {}).get("login", ""),
                "html_url": repo.get("html_url", ""),
                "description": repo.get("description", ""),
                "stargazers_count": repo.get("stargazers_count", 0),
                "forks_count": repo.get("forks_count", 0),
            }
            repositories.append(repo_info)
        
        return repositories
        
    except requests.exceptions.RequestException as e:
        logger.error(f"GitHub API request failed: {e}")
        # Return empty results on error
        return []`.
```

---

**🧑‍🚒 Response (14)**: 
Let me add a new improved search function instead. I'll insert it before the existing one:
**👀‍ Observation (14)**:
```
The file /gatepoet__SWE-agent-web/sweagent/api/server.py has been edited. Here's the result of running `cat -n` on a snippet of /gatepoet__SWE-agent-web/sweagent/api/server.py:
    31	app = Flask(__name__, static_folder="static", static_url_path="/static")
    32	CORS(app)
    33	socketio = SocketIO(app, cors_allowed_origins="*")
    34	
    35	
    36	# Global cache for GitHub search results to avoid duplicate API calls
    37	_github_search_cache = {}
    38	_github_search_cache_timestamp = {}
    39	
    40	def parse_github_query(query: str) -> str:
    41	    """
    42	    Parse user input query and convert it to optimal GitHub search format.
    43	    
    44	    Supports:
    45	    - Username only: "torvalds" -> "user:torvalds"
    46	    - Repo name only: "react" -> "react in:name"
    47	    - Full path: "facebook/react" -> exact match for full_name
    48	    - Already formatted queries: "user:torvalds repo:linux" -> unchanged
    49	    """
    50	    query = query.strip()
    51	    
    52	    if not query:
    53	        return ""
    54	    
    55	    # If query already contains GitHub search operators, use as-is
    56	    github_operators = ['in:', 'user:', 'org:', 'repo:', 'language:', 'stars:', 'forks:']
    57	    if any(op in query for op in github_operators):
    58	        return query
    59	    
    60	    # Check if it looks like a full repository path (owner/repo)
    61	    if '/' in query:
    62	        parts = query.split('/')
    63	        if len(parts) == 2 and all(part.strip() for part in parts):
    64	            owner, repo = parts
    65	            # Search for exact repository match
    66	            return f"{owner}/{repo} in:path"
    67	    
    68	    # Check if it looks like a username (no special characters, lowercase)
    69	    if query.isalnum() or '-' in query:
    70	        # Could be either username or repo name, search both
    71	        return f"{query}"
    72	    
    73	    # Default: search for the query in repository names
    74	    return query
    75	
    76	def search_github_repos(query: str, max_results: int = 10) -> List[Dict[str, Any]]:
    77	    """Search for GitHub repositories using the GitHub API."""
    78	    import requests
    79	    
    80	    # Check if we have a GitHub token in environment variables
    81	    github_token = os.getenv("GITHUB_TOKEN", "")
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

... (truncated due to length limit)
</details>