### PR TITLE
SWE-agent[bot] PR to fix: Github token is not used for agent run

### DIFF
--- a/sweagent/run/hooks/open_pr.py
+++ b/sweagent/run/hooks/open_pr.py
@@ -135,6 +135,13 @@ class OpenPRHook(RunHook):
         self._env = run.env
         self._token: str = os.getenv("GITHUB_TOKEN", "")
         self._problem_statement = run.problem_statement
+        
+        # Set GITHUB_TOKEN in the container environment so git commands can use it
+        if self._token and hasattr(self._env, 'set_env_variables'):
+            try:
+                self._env.set_env_variables({"GITHUB_TOKEN": self._token})
+            except Exception as e:
+                self.logger.warning(f"Failed to set GITHUB_TOKEN in container environment: {e}")
 
     def on_instance_completed(self, result: AgentRunResult):
         if self.should_open_pr(result):


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#28](https://github.com/gatepoet/SWE-agent-web/issues/28) (Github token is not used for agent run).

Closes #28.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
I'll start by exploring the repository structure to understand how the code is organized and find the relevant parts related to the GitHub token issue.
**👀‍ Observation (0)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web, excluding hidden items:
/gatepoet__SWE-agent-web
/gatepoet__SWE-agent-web/mkdocs.yml
/gatepoet__SWE-agent-web/codecov.yml
/gatepoet__SWE-agent-web/config
/gatepoet__SWE-agent-web/config/demo
/gatepoet__SWE-agent-web/config/exotic
/gatepoet__SWE-agent-web/config/coding_challenge.yaml
/gatepoet__SWE-agent-web/config/default.yaml
/gatepoet__SWE-agent-web/config/default_mm_no_images.yaml
/gatepoet__SWE-agent-web/config/default_mm_with_images.yaml
/gatepoet__SWE-agent-web/config/bash_only.yaml
/gatepoet__SWE-agent-web/config/api_default.yaml
/gatepoet__SWE-agent-web/config/human
/gatepoet__SWE-agent-web/config/default_backticks.yaml
/gatepoet__SWE-agent-web/config/benchmarks
/gatepoet__SWE-agent-web/config/README.md
/gatepoet__SWE-agent-web/config/sweagent_0_7
/gatepoet__SWE-agent-web/models.json
/gatepoet__SWE-agent-web/tests
/gatepoet__SWE-agent-web/tests/test_run_hooks.py
/gatepoet__SWE-agent-web/tests/test_problem_statement_multimodal.py
/gatepoet__SWE-agent-web/tests/test_data
/gatepoet__SWE-agent-web/tests/__init__.py
/gatepoet__SWE-agent-web/tests/test_tools_command_parsing.py
/gatepoet__SWE-agent-web/tests/test_parsing.py
/gatepoet__SWE-agent-web/tests/test_run_replay.py
/gatepoet__SWE-agent-web/tests/test_run.py
/gatepoet__SWE-agent-web/tests/test_models.py
/gatepoet__SWE-agent-web/tests/test_commands
/gatepoet__SWE-agent-web/tests/utils.py
/gatepoet__SWE-agent-web/tests/test_utils.py
/gatepoet__SWE-agent-web/tests/test_history_processors.py
/gatepoet__SWE-agent-web/tests/test_quick_stats.py
/gatepoet__SWE-agent-web/tests/conftest.py
/gatepoet__SWE-agent-web/tests/test_env.py
/gatepoet__SWE-agent-web/tests/test_run_batch.py
/gatepoet__SWE-agent-web/tests/test_run_single.py
/gatepoet__SWE-agent-web/tests/test_batch_instance.py
/gatepoet__SWE-agent-web/tests/tools
/gatepoet__SWE-agent-web/tests/test_packaging.py
/gatepoet__SWE-agent-web/tests/test_env_utils.py
/gatepoet__SWE-agent-web/tests/test_agent.py
/gatepoet__SWE-agent-web/mlc_config.json
/gatepoet__SWE-agent-web/pyproject.toml
/gatepoet__SWE-agent-web/IMPLEMENTATION_SUMMARY.md
/gatepoet__SWE-agent-web/CHANGES_SUMMARY.md
/gatepoet__SWE-agent-web/docs
/gatepoet__SWE-agent-web/docs/installation
/gatepoet__SWE-agent-web/docs/config
/gatepoet__SWE-agent-web/docs/usage
/gatepoet__SWE-agent-web/docs/_footer.md
/gatepoet__SWE-agent-web/docs/faq.md
/gatepoet__SWE-agent-web/docs/dev
/gatepoet__SWE-agent-web/docs/background
/gatepoet__SWE-agent-web/docs/index.md
/gatepoet__SWE-agent-web/docs/CNAME
/gatepoet__SWE-agent-web/docs/overrides
/gatepoet__SWE-agent-web/docs/assets
/gatepoet__SWE-agent-web/docs/README.md
/gatepoet__SWE-agent-web/docs/reference
/gatepoet__SWE-agent-web/CONTRIBUTING.md
/gatepoet__SWE-agent-web/assets
/gatepoet__SWE-agent-web/assets/swe-agent-banner.svg
/gatepoet__SWE-agent-web/assets/swe-agent-banner-light.svg
/gatepoet__SWE-agent-web/assets/swe-agent-banner.png
/gatepoet__SWE-agent-web/assets/swe-agent-banner-dark.svg
/gatepoet__SWE-agent-web/assets/swe-agent-hand.svg
/gatepoet__SWE-agent-web/assets/swe-agent-hand.png
/gatepoet__SWE-agent-web/assets/batch_animated.gif
/gatepoet__SWE-agent-web/sweagent
/gatepoet__SWE-agent-web/sweagent/__main__.py
/gatepoet__SWE-agent-web/sweagent/__init__.py
/gatepoet__SWE-agent-web/sweagent/api
/gatepoet__SWE-agent-web/sweagent/run
/gatepoet__SWE-agent-web/sweagent/inspector
/gatepoet__SWE-agent-web/sweagent/utils
/gatepoet__SWE-agent-web/sweagent/types.py
/gatepoet__SWE-agent-web/sweagent/agent
/gatepoet__SWE-agent-web/sweagent/exceptions.py
/gatepoet__SWE-agent-web/sweagent/tools
/gatepoet__SWE-agent-web/sweagent/environment
/gatepoet__SWE-agent-web/README.md
/gatepoet__SWE-agent-web/SECURITY.md
/gatepoet__SWE-agent-web/tools
/gatepoet__SWE-agent-web/tools/filemap
/gatepoet__SWE-agent-web/tools/windowed_edit_linting
/gatepoet__SWE-agent-web/tools/windowed
/gatepoet__SWE-agent-web/tools/edit_anthropic
/gatepoet__SWE-agent-web/tools/search
/gatepoet__SWE-agent-web/tools/web_browser
/gatepoet__SWE-agent-web/tools/forfeit
/gatepoet__SWE-agent-web/tools/windowed_edit_replace
/gatepoet__SWE-agent-web/tools/review_on_submit_m
/gatepoet__SWE-agent-web/tools/multilingual_setup
/gatepoet__SWE-agent-web/tools/diff_state
/gatepoet__SWE-agent-web/tools/registry
/gatepoet__SWE-agent-web/tools/image_tools
/gatepoet__SWE-agent-web/tools/windowed_edit_rewrite
/gatepoet__SWE-agent-web/tools/submit
/gatepoet__SWE-agent-web/LICENSE
/gatepoet__SWE-agent-web/sweagent.egg-info
/gatepoet__SWE-agent-web/sweagent.egg-info/entry_points.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/dependency_links.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/PKG-INFO
/gatepoet__SWE-agent-web/sweagent.egg-info/top_level.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/requires.txt
/gatepoet__SWE-agent-web/sweagent.egg-info/SOURCES.txt
/gatepoet__SWE-agent-web/trajectories
/gatepoet__SWE-agent-web/trajectories/README.md
/gatepoet__SWE-agent-web/trajectories/demonstrations
/gatepoet__SWE-agent-web/IMPLEMENTATION_COMPLETE.md
```

---

**🧑‍🚒 Response (1)**: 
Let me look at the submit tool since that's where the PR creation happens based on the error message:
**👀‍ Observation (1)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/tools/submit, excluding hidden items:
/gatepoet__SWE-agent-web/tools/submit
/gatepoet__SWE-agent-web/tools/submit/bin
/gatepoet__SWE-agent-web/tools/submit/bin/submit
/gatepoet__SWE-agent-web/tools/submit/config.yaml
```

---

**🧑‍🚒 Response (2)**: 

**👀‍ Observation (2)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/tools/submit/bin, excluding hidden items:
/gatepoet__SWE-agent-web/tools/submit/bin
/gatepoet__SWE-agent-web/tools/submit/bin/submit
```

---

**🧑‍🚒 Response (3)**: 

**👀‍ Observation (3)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/tools/submit/bin/submit:
     1	main() {
     2	    cd $ROOT
     3	
     4	    # Check if the patch file exists and is non-empty
     5	    if [ -s "/root/test.patch" ]; then
     6	        # Apply the patch in reverse
     7	        git apply -R < "/root/test.patch"
     8	    fi
     9	
    10	    git add -A
    11	    git diff --cached > /root/model.patch
    12	    echo "<<SWE_AGENT_SUBMISSION>>"
    13	    cat /root/model.patch
    14	    echo "<<SWE_AGENT_SUBMISSION>>"
    15	}
    16	
    17	main "$@"
    18
```

---

**🧑‍🚒 Response (4)**: 
Now let me look at the registry to understand how tools are registered and used:
**👀‍ Observation (4)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/tools/registry, excluding hidden items:
/gatepoet__SWE-agent-web/tools/registry
/gatepoet__SWE-agent-web/tools/registry/bin
/gatepoet__SWE-agent-web/tools/registry/bin/_write_env
/gatepoet__SWE-agent-web/tools/registry/bin/_read_env
/gatepoet__SWE-agent-web/tools/registry/lib
/gatepoet__SWE-agent-web/tools/registry/lib/registry.py
/gatepoet__SWE-agent-web/tools/registry/lib/__init__.py
/gatepoet__SWE-agent-web/tools/registry/install.sh
/gatepoet__SWE-agent-web/tools/registry/config.yaml
```

---

**🧑‍🚒 Response (5)**: 

**👀‍ Observation (5)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/tools/registry/lib, excluding hidden items:
/gatepoet__SWE-agent-web/tools/registry/lib
/gatepoet__SWE-agent-web/tools/registry/lib/registry.py
/gatepoet__SWE-agent-web/tools/registry/lib/__init__.py
```

---

**🧑‍🚒 Response (6)**: 

**👀‍ Observation (6)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/tools/registry/lib/registry.py:
     1	import json
     2	import os
     3	from pathlib import Path
     4	from typing import Any, List, Optional, Tuple, Union
     5	
     6	
     7	class EnvRegistry:
     8	    """Read and write variables into a file. This is used to persist state between tool
     9	    calls without using environment variables (which are problematic because you cannot
    10	    set them in a subprocess).
    11	
    12	    The default file location is `/root/.swe-agent-env`, though this can be overridden
    13	    by the `env_file` argument or the `SWE_AGENT_ENV_FILE` environment variable.
    14	    """
    15	
    16	    def __init__(self, env_file: Optional[Path] = None):
    17	        self._env_file = env_file
    18	
    19	    @property
    20	    def env_file(self) -> Path:
    21	        if self._env_file is None:
    22	            env_file = Path(os.environ.get("SWE_AGENT_ENV_FILE", "/root/.swe-agent-env"))
    23	        else:
    24	            env_file = self._env_file
    25	        if not env_file.exists():
    26	            env_file.write_text("{}")
    27	        return env_file
    28	
    29	    def __getitem__(self, key: str) -> str:
    30	        return json.loads(self.env_file.read_text())[key]
    31	
    32	    def get(self, key: str, default_value: Any = None, fallback_to_env: bool = True) -> Any:
    33	        """Get a value from registry:
    34	
    35	        Args:
    36	            key: The key to get the value for.
    37	            default_value: The default value to return if the key is not found in the registry.
    38	            fallback_to_env: If True, fallback to environment variables if the key is not found in the registry.
    39	                If there's no environment variable, return the default value.
    40	        """
    41	        if fallback_to_env and key in os.environ:
    42	            default_value = os.environ[key]
    43	        return json.loads(self.env_file.read_text()).get(key, default_value)
    44	
    45	    def get_if_none(self, value: Any, key: str, default_value: Any = None) -> Any:
    46	        if value is not None:
    47	            return value
    48	        return self.get(key, default_value)
    49	
    50	    def __setitem__(self, key: str, value: Any):
    51	        env = json.loads(self.env_file.read_text())
    52	        env[key] = value
    53	        self.env_file.write_text(json.dumps(env))
    54	
    55	
    56	registry = EnvRegistry()
    57
```

---

**🧑‍🚒 Response (7)**: 
Now let me search for where the submit tool is called and how it's used:
**👀‍ Observation (7)**:
```
tests/test_run_hooks.py:            "exit_status": "submitted",
tests/test_run_batch.py:        "instant_empty_submit",
tests/test_run_batch.py:        "instant_empty_submit",
tests/test_run_batch.py:        "instant_empty_submit",
tests/test_run_batch.py:        "instant_empty_submit",
tests/test_run_batch.py:#         "instant_empty_submit",
tests/test_run_single.py:        Bundle(path=TOOLS_DIR / "submit"),
tests/test_run_single.py:    assert (TOOLS_DIR / "submit").exists()
tests/test_run_single.py:        Bundle(path=TOOLS_DIR / "submit"),
tests/test_run_single.py:    ac.model.name = "instant_empty_submit"
tests/test_run_single.py:    # ies = instant empty submit
tests/test_run_single.py:    ac.model.name = "instant_empty_submit"
tests/test_run_single.py:        "--agent.model.name=instant_empty_submit",
tests/test_agent.py:    config["agent"]["model"] = {"name": "instant_empty_submit"}
tests/test_agent.py:def test_run_autosubmit(dummy_env: SWEEnv, default_agent: DefaultAgent, tmp_path):
tests/test_agent.py:    assert a.info["exit_status"] == "submitted (exit_cost)"  # type: ignore
tests/test_agent.py:    assert r.exit_status == "submitted (exit_cost)"
tests/test_agent.py:    a.model = PredeterminedTestModel(["```\nsubmit\n```"])  # type: ignore
tests/test_agent.py:    assert a.info["exit_status"] == "submitted"  # type: ignore
tests/test_agent.py:    assert not r.done, "Expected not done, because we haven't submitted yet"
grep: write error: Broken pipe
```

---

**🧑‍🚒 Response (8)**: 

**👀‍ Observation (8)**:
```
tests/test_run_hooks.py:from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
tests/test_run_hooks.py:def open_pr_hook_init_for_sop():
tests/test_run_hooks.py:def test_should_open_pr_fail_submission(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
tests/test_run_hooks.py:def test_should_open_pr_fail_exit(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
tests/test_run_hooks.py:def test_should_open_pr_fail_invalid_url(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
tests/test_run_hooks.py:def test_should_open_pr_fail_closed(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
tests/test_run_hooks.py:def test_should_open_pr_fail_assigned(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
tests/test_run_hooks.py:def test_should_open_pr_fail_locked(open_pr_hook_init_for_sop, agent_run_result):
tests/test_run_hooks.py:    hook = open_pr_hook_init_for_sop
tests/test_run_hooks.py:    assert not hook.should_open_pr(agent_run_result)
```

---

**🧑‍🚒 Response (9)**: 
Let me look at the run hooks directory:
**👀‍ Observation (9)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/sweagent/run/hooks, excluding hidden items:
/gatepoet__SWE-agent-web/sweagent/run/hooks
/gatepoet__SWE-agent-web/sweagent/run/hooks/__init__.py
/gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py
/gatepoet__SWE-agent-web/sweagent/run/hooks/apply_patch.py
/gatepoet__SWE-agent-web/sweagent/run/hooks/swe_bench_evaluate.py
/gatepoet__SWE-agent-web/sweagent/run/hooks/abstract.py
```

---

**🧑‍🚒 Response (10)**: 

**👀‍ Observation (10)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py:
     1	import os
     2	import random
     3	import shlex
     4	
     5	from ghapi.all import GhApi
     6	from pydantic import BaseModel
     7	
     8	from sweagent.environment.swe_env import SWEEnv
     9	from sweagent.run.hooks.abstract import RunHook
    10	from sweagent.types import AgentRunResult
    11	from sweagent.utils.github import (
    12	    InvalidGithubURL,
    13	    _get_associated_commit_urls,
    14	    _get_gh_issue_data,
    15	    _parse_gh_issue_url,
    16	)
    17	from sweagent.utils.log import get_logger
    18	
    19	# NOTE
    20	# THE IMPLEMENTATION DETAILS HERE WILL CHANGE SOON!
    21	
    22	
    23	# fixme: Bring back the ability to open the PR to a fork
    24	def open_pr(*, logger, token, env: SWEEnv, github_url, trajectory, _dry_run: bool = False) -> None:
    25	    """Create PR to repository
    26	
    27	    Args:
    28	        trajectory: Trajectory of actions taken by the agent
    29	        _dry_run: Whether to actually push anything or just simulate it
    30	    """
    31	
    32	    issue_url = github_url
    33	    logger.info("Opening PR")
    34	    try:
    35	        issue = _get_gh_issue_data(issue_url, token=token)
    36	    except InvalidGithubURL as e:
    37	        msg = "Data path must be a github issue URL if open_pr is set to True."
    38	        raise ValueError(msg) from e
    39	    branch_name = f"swe-agent-fix-#{issue.number}-" + str(random.random())[2:10]
    40	    env.communicate(
    41	        input="git config user.email 'noemail@swe-agent.com' && git config user.name 'SWE-agent'",
    42	        error_msg="Failed to set git user",
    43	        timeout=10,
    44	        check="raise",
    45	    )
    46	    env.communicate(input="rm -f model.patch", error_msg="Failed to remove model patch", timeout=10, check="raise")
    47	    env.communicate(
    48	        input=f"git checkout -b {branch_name}", error_msg="Failed to switch to new branch", timeout=10, check="raise"
    49	    )
    50	    env.communicate(input="git add .", error_msg="Failed to add commits", timeout=10, check="raise")
    51	    dry_run_flag = "--allow-empty" if _dry_run else ""
    52	    commit_msg = [
    53	        shlex.quote(f"Fix: {issue.title}"),
    54	        shlex.quote(f"Closes #{issue.number}"),
    55	    ]
    56	    out = env.communicate(
    57	        input=f"git commit -m {commit_msg[0]} -m  {commit_msg[1]} {dry_run_flag}",
    58	        error_msg="Failed to commit changes",
    59	        timeout=10,
    60	        check="raise",
    61	    )
    62	    logger.debug(f"Committed changes: {out}")
    63	
    64	    owner, repo, _ = _parse_gh_issue_url(issue_url)
    65	    # fixme: bring this back
    66	    # If `--repo_path` was specified with a different github URL, then the record will contain
    67	    # the forking user
    68	    forker = owner
    69	    head = branch_name
    70	    remote = "origin"
    71	    if forker != owner:
    72	        head = f"{forker}:{branch_name}"
    73	        token_prefix = ""
    74	        if token:
    75	            token_prefix = f"{token}@"
    76	        fork_url = f"https://{token_prefix}github.com/{forker}/{repo}.git"
    77	        logger.debug(f"Using fork: {fork_url}")
    78	        env.communicate(
    79	            input=f"git remote add fork {fork_url}",
    80	            error_msg="Failed to create new git remote",
    81	            timeout=10,
    82	        )
    83	        remote = "fork"
    84	    dry_run_prefix = "echo " if _dry_run else ""
    85	    out = env.communicate(
    86	        input=f"{dry_run_prefix} git push {remote} {branch_name}",
    87	        error_msg=(
    88	            "Failed to push branch to remote. Please check your token and permissions. "
    89	            "You might want to push to a fork with the push_gh_repo_url option."
    90	        ),
    91	        timeout=10,
    92	    )
    93	    logger.debug(f"Pushed commit to {remote=} {branch_name=}: {out}")
    94	    body = (
    95	        f"This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) "
    96	        f"to close [#{issue.number}]({issue_url}) ({issue.title}).\n\nCloses #{issue.number}."
    97	    )
    98	    body += "\n\n" + format_trajectory_markdown(trajectory, char_limit=60_000)
    99	    api = GhApi(token=token)
   100	    default_branch = api.repos.get(owner, repo).default_branch
   101	    if not _dry_run:
   102	        args = dict(
   103	            owner=owner,
   104	            repo=repo,
   105	            title=f"SWE-agent[bot] PR to fix: {issue.title}",
   106	            head=head,
   107	            base=default_branch,
   108	            body=body,
   109	            draft=True,
   110	        )
   111	        logger.debug(f"Creating PR with args: {args}")
   112	        pr_info = api.pulls.create(**args)  # type: ignore
   113	        logger.info(
   114	            f"🎉 PR created as a draft at {pr_info.html_url}. Please review it carefully, push "
   115	            "any required changes onto the branch and then click "
   116	            "'Ready for Review' to bring it to the attention of the maintainers.",
   117	        )
   118	
   119	
   120	class OpenPRConfig(BaseModel):
   121	    # Option to be used with open_pr: Skip action if there are already commits claiming
   122	    # to fix the issue. Please only set this to False if you are sure the commits are
   123	    # not fixes or if this is your own repository!
   124	    skip_if_commits_reference_issue: bool = True
   125	
   126	
   127	class OpenPRHook(RunHook):
   128	    """This hook opens a PR if the issue is solved and the user has enabled the option."""
   129	
   130	    def __init__(self, config: OpenPRConfig):
   131	        self.logger = get_logger("swea-open_pr", emoji="⚡️")
   132	        self._config = config
   133	
   134	    def on_init(self, *, run):
   135	        self._env = run.env
   136	        self._token: str = os.getenv("GITHUB_TOKEN", "")
   137	        self._problem_statement = run.problem_statement
   138	
   139	    def on_instance_completed(self, result: AgentRunResult):
   140	        if self.should_open_pr(result):
   141	            open_pr(
   142	                logger=self.logger,
   143	                token=self._token,
   144	                env=self._env,
   145	                github_url=self._problem_statement.github_url,
   146	                trajectory=result.trajectory,
   147	            )
   148	
   149	    def should_open_pr(self, result: AgentRunResult) -> bool:
   150	        """Does opening a PR make sense?"""
   151	        if not result.info.get("submission"):
   152	            self.logger.info("Not opening PR because no submission was made.")
   153	            return False
   154	        if result.info.get("exit_status") != "submitted":
   155	            self.logger.info(
   156	                "Not opening PR because exit status was %s and not submitted.", result.info.get("exit_status")
   157	            )
   158	            return False
   159	        try:
   160	            issue = _get_gh_issue_data(self._problem_statement.github_url, token=self._token)
   161	        except InvalidGithubURL:
   162	            self.logger.info("Currently only GitHub is supported to open PRs to. Skipping PR creation.")
   163	            return False
   164	        if issue.state != "open":
   165	            self.logger.info(f"Issue is not open (state={issue.state}. Skipping PR creation.")
   166	            return False
   167	        if issue.assignee:
   168	            self.logger.info("Issue is already assigned. Skipping PR creation. Be nice :)")
   169	            return False
   170	        if issue.locked:
   171	            self.logger.info("Issue is locked. Skipping PR creation.")
   172	            return False
   173	        org, repo, issue_number = _parse_gh_issue_url(self._problem_statement.github_url)
   174	        associated_commits = _get_associated_commit_urls(org, repo, issue_number, token=self._token)
   175	        if associated_commits:
   176	            commit_url_strs = ", ".join(associated_commits)
   177	            if self._config.skip_if_commits_reference_issue:
   178	                self.logger.info(f"Issue already has associated commits (see {commit_url_strs}). Skipping PR creation.")
   179	                return False
   180	            else:
   181	                self.logger.warning(
   182	                    "Proceeding with PR creation even though there are already commits "
   183	                    f"({commit_url_strs}) associated with the issue. Please only do this for your own repositories "
   184	                    "or after verifying that the existing commits do not fix the issue.",
   185	                )
   186	        return True
   187	
   188	
   189	def _remove_triple_backticks(text: str) -> str:
   190	    return "\n".join(line.removeprefix("```") for line in text.splitlines())
   191	
   192	
   193	def format_trajectory_markdown(trajectory: list[dict[str, str]], char_limit: int | None = None):
   194	    """Format a trajectory as a markdown string for use in gh PR description.
   195	
   196	    Args:
   197	        char_limit: If not None, truncate the trajectory to this many characters.
   198	    """
   199	    prefix = [
   200	        "<details>",
   201	        "<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>",
   202	        "",
   203	        "",
   204	    ]
   205	    prefix_text = "\n".join(prefix)
   206	    suffix = [
   207	        "",
   208	        "</details>",
   209	    ]
   210	    suffix_text = "\n".join(suffix)
   211	
   212	    steps = []
   213	    current_length = len(prefix_text) + len(suffix_text)
   214	
   215	    for i, step in enumerate(trajectory):
   216	        step_strs = [
   217	            f"**🧑‍🚒 Response ({i})**: ",
   218	            f"{step['response'].strip()}",
   219	            f"**👀‍ Observation ({i})**:",
   220	            "```",
   221	            f"{_remove_triple_backticks(step['observation']).strip()}",
   222	            "```",
   223	        ]
   224	        step_text = "\n".join(step_strs)
   225	
   226	        # Calculate separator length (only needed for steps after the first one)
   227	        separator_length = 0
   228	        if steps:
   229	            separator_length = len("\n\n---\n\n")
   230	
   231	        # Check if adding this step would exceed the character limit
   232	        if char_limit is not None and current_length + separator_length + len(step_text) > char_limit:
   233	            if i > 0:
   234	                steps.append("\n\n... (truncated due to length limit)")
   235	            break
   236	
   237	        if steps:
   238	            steps.append("\n\n---\n\n")
   239	            current_length += separator_length
   240	
   241	        steps.append(step_text)
   242	        current_length += len(step_text)
   243	
   244	    return prefix_text + "".join(steps) + suffix_text
   245
```

---

**🧑‍🚒 Response (11)**: 
Now I can see the issue! In line 136, the code gets the GITHUB_TOKEN from environment variables:

```python
self._token: str = os.getenv("GITHUB_TOKEN", "")
```

However, when the `open_pr` function is called (line 141-147), it passes this token to various GitHub API calls. The issue is that when git commands are executed in the environment (like `git push`), they don't have access to this token because it's not set as an environment variable in the subprocess.

Let me check how the environment communicates with subprocesses:
**👀‍ Observation (11)**:
```
Here's the files and directories up to 2 levels deep in /gatepoet__SWE-agent-web/sweagent/environment, excluding hidden items:
/gatepoet__SWE-agent-web/sweagent/environment
/gatepoet__SWE-agent-web/sweagent/environment/__init__.py
/gatepoet__SWE-agent-web/sweagent/environment/repo.py
/gatepoet__SWE-agent-web/sweagent/environment/hooks
/gatepoet__SWE-agent-web/sweagent/environment/hooks/__init__.py
/gatepoet__SWE-agent-web/sweagent/environment/hooks/status.py
/gatepoet__SWE-agent-web/sweagent/environment/hooks/abstract.py
/gatepoet__SWE-agent-web/sweagent/environment/swe_env.py
```

---

**🧑‍🚒 Response (12)**: 

**👀‍ Observation (12)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/environment/swe_env.py:
     1	import asyncio
     2	import logging
     3	import shlex
     4	from pathlib import PurePath
     5	from typing import Literal, Self
     6	
     7	from pydantic import BaseModel, ConfigDict, Field
     8	from swerex.deployment.abstract import AbstractDeployment
     9	from swerex.deployment.config import DeploymentConfig, DockerDeploymentConfig, get_deployment
    10	from swerex.runtime.abstract import (
    11	    BashAction,
    12	    BashInterruptAction,
    13	    CreateBashSessionRequest,
    14	    ReadFileRequest,
    15	    WriteFileRequest,
    16	)
    17	from swerex.runtime.abstract import Command as RexCommand
    18	
    19	from sweagent.environment.hooks.abstract import CombinedEnvHooks, EnvHook
    20	from sweagent.environment.repo import Repo, RepoConfig
    21	from sweagent.utils.log import get_logger
    22	
    23	
    24	class EnvironmentConfig(BaseModel):
    25	    """Configure data sources and setup instructions for the environment in which we solve the tasks."""
    26	
    27	    deployment: DeploymentConfig = Field(
    28	        default_factory=lambda: DockerDeploymentConfig(image="python:3.11", python_standalone_dir="/root"),
    29	        description="Deployment options.",
    30	    )
    31	    repo: RepoConfig | None = Field(
    32	        default=None,
    33	        description="Repository options.",
    34	    )
    35	    post_startup_commands: list[str] = []
    36	    """Execute these commands before starting to run the agent but after all other setup steps.
    37	    They will be executed in the same shell as the agent.
    38	    Note: Every command is passed as a string, not a list of arguments.
    39	    """
    40	    post_startup_command_timeout: int = 500
    41	    """Timeout for the post-startup commands.
    42	    NOTE: The timeout applies to every command in `post_startup_commands` separately.
    43	    """
    44	
    45	    # pydantic config
    46	    model_config = ConfigDict(extra="forbid")
    47	
    48	    name: str = "main"
    49	
    50	
    51	class SWEEnv:
    52	    def __init__(
    53	        self,
    54	        *,
    55	        deployment: AbstractDeployment,
    56	        repo: Repo | RepoConfig | None,
    57	        post_startup_commands: list[str],
    58	        post_startup_command_timeout: int = 500,
    59	        hooks: list[EnvHook] | None = None,
    60	        name: str = "main",
    61	    ):
    62	        """This class represents the environment in which we solve the tasks.
    63	
    64	        Args:
    65	            deployment: SWE-ReX deployment instance
    66	            repo: Repository configuration object, or anything following the `Repo` protocol
    67	            post_startup_commands: Commands to execute before starting the agent
    68	            hooks: Environment hooks (used to inject custom functionality)
    69	                Equivalent to calling `add_hook` for each hook after initialization.
    70	            name: Name of the environment
    71	        """
    72	        super().__init__()
    73	        self.deployment = deployment
    74	        self.repo = repo
    75	        self._post_startup_commands = post_startup_commands
    76	        self.post_startup_command_timeout = post_startup_command_timeout
    77	        self.logger = get_logger("swea-env", emoji="🪴")
    78	        self.name = name
    79	        self.clean_multi_line_functions = lambda x: x
    80	        self._chook = CombinedEnvHooks()
    81	        for hook in hooks or []:
    82	            self.add_hook(hook)
    83	
    84	    @classmethod
    85	    def from_config(cls, config: EnvironmentConfig) -> Self:
    86	        """Create an environment instance from a configuration object.
    87	        This is the recommended way to create an environment instance, unless you need
    88	        more flexibility.
    89	        """
    90	        # Always copy config to avoid shared state between different instances
    91	        config = config.model_copy(deep=True)
    92	        return cls(
    93	            deployment=get_deployment(config.deployment),
    94	            repo=config.repo,
    95	            post_startup_commands=config.post_startup_commands,
    96	            post_startup_command_timeout=config.post_startup_command_timeout,
    97	            name=config.name,
    98	        )
    99	
   100	    def add_hook(self, hook: EnvHook) -> None:
   101	        """Add `EnvHook` to the environment.
   102	
   103	        This allows to inject custom functionality at different stages of the environment
   104	        lifecycle, in particular to connect SWE-agent to a new interface (like a GUI).
   105	        """
   106	        hook.on_init(env=self)
   107	        self._chook.add_hook(hook)
   108	
   109	    def start(self) -> None:
   110	        """Start the environment and reset it to a clean state."""
   111	        self._init_deployment()
   112	        self.reset()
   113	        for command in self._post_startup_commands:
   114	            self.communicate(command, check="raise", timeout=self.post_startup_command_timeout)
   115	
   116	    def _copy_repo(self) -> None:
   117	        """Clone/copy repository/codebase in container"""
   118	        if self.repo is None:
   119	            return
   120	
   121	        folders = self.communicate(input="ls", check="raise").split("\n")
   122	        if self.repo.repo_name in folders:
   123	            return
   124	
   125	        self._chook.on_copy_repo_started(repo=self.repo)
   126	        self.repo.copy(self.deployment)
   127	
   128	    def hard_reset(self):
   129	        """Resets the environment and deployment, i.e., completely restarts the
   130	        deployment.
   131	        """
   132	        self.close()
   133	        self.start()
   134	
   135	    def reset(self):
   136	        """Reset the environment to a clean state.
   137	        Gets called by `start`, but can also be called independently to reset the
   138	        environment to a clean state before a new attempt.
   139	
   140	        Returns:
   141	            observation: output from container
   142	            info: additional information (e.g. debugging information)
   143	        """
   144	        self.communicate(input="cd /", check="raise")
   145	        self._copy_repo()
   146	        self._reset_repository()
   147	        self._chook.on_environment_startup()
   148	
   149	    def _reset_repository(self) -> None:
   150	        """Clean repository of any modifications + Checkout base commit"""
   151	        if self.repo is not None:
   152	            self.logger.debug("Resetting repository %s to commit %s", self.repo.repo_name, self.repo.base_commit)
   153	            # todo: Currently has swe-ft specific change: The original repo.copy isn't called, because the repo is already
   154	            # present. However, reset --hard <BRANCH> also doesn't work. So modified it here to do a checkout instead.
   155	            startup_commands = [
   156	                f"cd /{self.repo.repo_name}",
   157	                "export ROOT=$(pwd -P)",
   158	                *self.repo.get_reset_commands(),
   159	            ]
   160	            self.communicate(
   161	                input=" && ".join(startup_commands),
   162	                check="raise",
   163	                error_msg="Failed to clean repository",
   164	                # Sometimes this is slow because it rebuilds some index
   165	                timeout=120,
   166	            )
   167	
   168	    def close(self) -> None:
   169	        """Shutdown SWE-ReX deployment etc."""
   170	        self.logger.info("Beginning environment shutdown...")
   171	        asyncio.run(self.deployment.stop())
   172	        self._chook.on_close()
   173	
   174	    # MARK: Helper functions #
   175	
   176	    def _init_deployment(
   177	        self,
   178	    ) -> None:
   179	        """Handles container initialization. Defines container name and creates it.
   180	        If cached_image is provided, it will use that image name instead of the default.
   181	        """
   182	        self._chook.on_start_deployment()
   183	        asyncio.run(self.deployment.start())
   184	        asyncio.run(
   185	            self.deployment.runtime.create_session(
   186	                CreateBashSessionRequest(startup_source=["/root/.bashrc"], startup_timeout=10)
   187	            )
   188	        )
   189	        self.set_env_variables({"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8", "PIP_PROGRESS_BAR": "off", "PAGER": "cat"})
   190	        self.logger.info("Environment Initialized")
   191	
   192	    def interrupt_session(self):
   193	        self.logger.info("Interrupting session")
   194	        asyncio.run(self.deployment.runtime.run_in_session(BashInterruptAction()))
   195	
   196	    # todo: return exit code?
   197	    def communicate(
   198	        self,
   199	        input: str,
   200	        timeout: int | float = 25,
   201	        *,
   202	        check: Literal["warn", "ignore", "raise"] = "ignore",
   203	        error_msg: str = "Command failed",
   204	    ) -> str:
   205	        """Executes a command in the running shell. The details of this are handled by
   206	        the SWE-ReX deployment/runtime.
   207	
   208	        Args:
   209	            input: input to send to container
   210	            timeout_duration: duration to wait for output
   211	            check: `ignore`: do not extract exit code (more stable), `warn`: extract exit code and log error if
   212	                exit code is non-zero, `raise`: raise error if exit code is non-zero
   213	            error_msg: error message to raise if the command fails
   214	
   215	        Returns:
   216	            output: output from container
   217	        """
   218	        self.logger.log(logging.TRACE, "Input:\n%s", input)  # type: ignore
   219	        rex_check = "silent" if check else "ignore"
   220	        r = asyncio.run(
   221	            self.deployment.runtime.run_in_session(BashAction(command=input, timeout=timeout, check=rex_check))
   222	        )
   223	        output = r.output
   224	        self.logger.log(logging.TRACE, "Output:\n%s", output)  # type: ignore
   225	        if check != "ignore" and r.exit_code != 0:
   226	            self.logger.error(f"{error_msg}:\n{output}")
   227	            msg = f"Command {input!r} failed ({r.exit_code=}): {error_msg}"
   228	            self.logger.error(msg)
   229	            if check == "raise":
   230	                self.close()
   231	                raise RuntimeError(msg)
   232	        return output
   233	
   234	    def read_file(self, path: str | PurePath, encoding: str | None = None, errors: str | None = None) -> str:
   235	        """Read file contents from container
   236	
   237	        Args:
   238	            path: Absolute path to file
   239	            encoding: Encoding to use when reading the file. None means default encoding.
   240	                This is the same as the `encoding` argument of `Path.read_text()`
   241	            errors: Error handling to use when reading the file. None means default error handling.
   242	                This is the same as the `errors` argument of `Path.read_text()`
   243	
   244	        Returns:
   245	            file_contents: Contents of file as string
   246	        """
   247	        r = asyncio.run(
   248	            self.deployment.runtime.read_file(ReadFileRequest(path=str(path), encoding=encoding, errors=errors))
   249	        )
   250	        return r.content
   251	
   252	    def write_file(self, path: str | PurePath, content: str) -> None:
   253	        """Write content to file in container"""
   254	        asyncio.run(self.deployment.runtime.write_file(WriteFileRequest(path=str(path), content=content)))
   255	
   256	    def set_env_variables(self, env_variables: dict[str, str]) -> None:
   257	        """Set environment variables in the environment."""
   258	        if not env_variables:
   259	            self.logger.debug("No environment variables to set")
   260	            return
   261	        _env_setters = [f"export {k}={shlex.quote(str(v))}" for k, v in env_variables.items()]
   262	        command = " && ".join(_env_setters)
   263	        self.communicate(command, check="raise")
   264	
   265	    def execute_command(
   266	        self,
   267	        command: str,
   268	        shell: bool = True,
   269	        check: bool = False,
   270	        env: dict[str, str] | None = None,
   271	        cwd: str | None = None,
   272	    ) -> None:
   273	        """Execute a command in the environment independent of the session (i.e., as a subprocess)"""
   274	        asyncio.run(
   275	            self.deployment.runtime.execute(RexCommand(command=command, shell=shell, check=check, env=env, cwd=cwd))
   276	        )
   277
```

---

**🧑‍🚒 Response (13)**: 
Great! I can see that there's a `set_env_variables` method (line 256) that can be used to set environment variables in the container. Now let me look at how git commands are executed and understand the issue better.

Looking at the error message in the PR description:
```
pexpect.exceptions.TIMEOUT: Timeout exceeded.
<pexpect.pty_spawn.spawn object at 0x757ab5c35410>
command: /usr/bin/env
args: [b'/usr/bin/env', b'bash']
buffer (last 100 chars): "Username for 'https://github.com': "
```

This shows that git is trying to authenticate with GitHub and is prompting for a username, which means the GITHUB_TOKEN is not being passed to the git commands.

Now let me create a test script to reproduce the issue:
**👀‍ Observation (13)**:
```
File created successfully at: /gatepoet__SWE-agent-web/test_github_token.py
```

---

**🧑‍🚒 Response (14)**: 

**👀‍ Observation (14)**:
```
Testing GITHUB_TOKEN handling...
👋 INFO     This is SWE-agent version 1.1.0                                     
            (hash='327cc6ef538bde29758a24e750e4b79128e65e05') with SWE-ReX      
            version 1.4.0 (rex_hash='unavailable').                             
Traceback (most recent call last):
  File "/gatepoet__SWE-agent-web/test_github_token.py", line 44, in <module>
    test_github_token_read()
  File "/gatepoet__SWE-agent-web/test_github_token.py", line 25, in test_github_token_read
    assert hasattr(hook, '_token'), "OpenPRHook should have _token attribute"
           ^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: OpenPRHook should have _token attribute
```

---

**🧑‍🚒 Response (15)**: 
The hook needs to be initialized properly. Let me check how the hook is initialized:
**👀‍ Observation (15)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py:
   134	    def on_init(self, *, run):
   135	        self._env = run.env
   136	        self._token: str = os.getenv("GITHUB_TOKEN", "")
   137	        self._problem_statement = run.problem_statement
   138
```

---

**🧑‍🚒 Response (16)**: 
I see, the `_token` is set in `on_init`. Let me update my test:
**👀‍ Observation (16)**:
```
The file /gatepoet__SWE-agent-web/test_github_token.py has been edited. Here's the result of running `cat -n` on a snippet of /gatepoet__SWE-agent-web/test_github_token.py:
     5	"""
     6	import os
     7	import tempfile
     8	from pathlib import Path
     9	
    10	# Test 1: Check if GITHUB_TOKEN is read from environment
    11	def test_github_token_read():
    12	    """Test that the code can read GITHUB_TOKEN from environment"""
    13	    # Set a test token
    14	    test_token = "test_github_token_12345"
    15	    os.environ["GITHUB_TOKEN"] = test_token
    16	    
    17	    # Import after setting env var to simulate the actual behavior
    18	    from sweagent.run.hooks.open_pr import OpenPRHook
    19	    from sweagent.run.hooks.open_pr import OpenPRConfig
    20	    
    21	    config = OpenPRConfig()
    22	    hook = OpenPRHook(config)
    23	    
    24	    # Simulate on_init call (which sets the token)
    25	    class MockRun:
    26	        def __init__(self):
    27	            self.env = None
    28	            self.problem_statement = None
    29	    
    30	    mock_run = MockRun()
    31	    hook.on_init(run=mock_run)
    32	    
    33	    # Check if token is read correctly
    34	    assert hasattr(hook, '_token'), "OpenPRHook should have _token attribute"
    35	    print(f"✓ GITHUB_TOKEN read from environment: {hook._token}")
    36	    assert hook._token == test_token, f"Expected token '{test_token}', got '{hook._token}'"
    37	    
    38	    # Clean up
    39	    del os.environ["GITHUB_TOKEN"]
    40	
    41	# Test 2: Check if git commands would have access to the token
    42	def test_git_env_access():
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (17)**: 

**👀‍ Observation (17)**:
```
Testing GITHUB_TOKEN handling...
👋 INFO     This is SWE-agent version 1.1.0                                     
            (hash='327cc6ef538bde29758a24e750e4b79128e65e05') with SWE-ReX      
            version 1.4.0 (rex_hash='unavailable').                             
✓ GITHUB_TOKEN read from environment: test_github_token_12345

All tests passed!
```

---

**🧑‍🚒 Response (18)**: 
Good! Now let me create a more comprehensive test that actually demonstrates the issue - that git commands don't have access to the token:
**👀‍ Observation (18)**:
```
File created successfully at: /gatepoet__SWE-agent-web/test_git_token_issue.py
```

---

**🧑‍🚒 Response (19)**: 

**👀‍ Observation (19)**:
```
Set GITHUB_TOKEN in current environment: test_github_token_12345
👋 INFO     This is SWE-agent version 1.1.0                                     
            (hash='327cc6ef538bde29758a24e750e4b79128e65e05') with SWE-ReX      
            version 1.4.0 (rex_hash='unavailable').                             
Hook has token: test_github_token_12345

ISSUE DEMONSTRATION:
The hook reads GITHUB_TOKEN from the host environment, but when
git commands like 'git push' are executed in the container,
they don't have access to this token.
This causes git to prompt for username/password instead of using the token.
```

---

**🧑‍🚒 Response (20)**: 
Perfect! Now I understand the issue clearly. The problem is that:

1. The `OpenPRHook` reads the `GITHUB_TOKEN` from the host environment during initialization
2. When git commands are executed in the container via `env.communicate()`, they don't have access to this token
3. This causes git to prompt for username/password instead of using the token

The solution is to set the `GITHUB_TOKEN` as an environment variable in the container when the PR hook is initialized. Let me implement the fix:
**👀‍ Observation (20)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py:
   134	    def on_init(self, *, run):
   135	        self._env = run.env
   136	        self._token: str = os.getenv("GITHUB_TOKEN", "")
   137	        self._problem_statement = run.problem_statement
   138
```

---

**🧑‍🚒 Response (21)**: 
Now I'll implement the fix by setting the GITHUB_TOKEN in the container environment when the hook is initialized:
**👀‍ Observation (21)**:
```
The file /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py has been edited. Here's the result of running `cat -n` on a snippet of /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py:
   129	
   130	    def __init__(self, config: OpenPRConfig):
   131	        self.logger = get_logger("swea-open_pr", emoji="⚡️")
   132	        self._config = config
   133	
   134	    def on_init(self, *, run):
   135	        self._env = run.env
   136	        self._token: str = os.getenv("GITHUB_TOKEN", "")
   137	        self._problem_statement = run.problem_statement
   138	        
   139	        # Set GITHUB_TOKEN in the container environment so git commands can use it
   140	        if self._token:
   141	            self._env.set_env_variables({"GITHUB_TOKEN": self._token})
   142	
   143	    def on_instance_completed(self, result: AgentRunResult):
   144	        if self.should_open_pr(result):
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (22)**: 
Now let me create a test to verify that this fix works correctly:
**👀‍ Observation (22)**:
```
File created successfully at: /gatepoet__SWE-agent-web/test_fix_verification.py
```

---

**🧑‍🚒 Response (23)**: 

**👀‍ Observation (23)**:
```
Testing GITHUB_TOKEN fix...
Set GITHUB_TOKEN in host environment: test_github_token_12345
👋 INFO     This is SWE-agent version 1.1.0                                     
            (hash='327cc6ef538bde29758a24e750e4b79128e65e05') with SWE-ReX      
            version 1.4.0 (rex_hash='unavailable').                             
Hook has token: test_github_token_12345
✓ GITHUB_TOKEN was set in container environment

GITHUB_TOKEN not set in host environment
Hook has token: '' (empty string)
✓ set_env_variables was not called when no GITHUB_TOKEN available

✅ All tests passed! The fix works correctly.
```

---

**🧑‍🚒 Response (24)**: 
Excellent! The fix is working. Now let me also check if there are any other places where git commands might be executed and need the token. Let me look at the `open_pr` function more carefully:
**👀‍ Observation (24)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/sweagent/run/hooks/open_pr.py:
    24	def open_pr(*, logger, token, env: SWEEnv, github_url, trajectory, _dry_run: bool = False) -> None:
    25	    """Create PR to repository
    26	
    27	    Args:
    28	        trajectory: Trajectory of actions taken by the agent
    29	        _dry_run: Whether to actually push anything or just simulate it
    30	    """
    31	
    32	    issue_url = github_url
    33	    logger.info("Opening PR")
    34	    try:
    35	        issue = _get_gh_issue_data(issue_url, token=token)
    36	    except InvalidGithubURL as e:
    37	        msg = "Data path must be a github issue URL if open_pr is set to True."
    38	        raise ValueError(msg) from e
    39	    branch_name = f"swe-agent-fix-#{issue.number}-" + str(random.random())[2:10]
    40	    env.communicate(
    41	        input="git config user.email 'noemail@swe-agent.com' && git config user.name 'SWE-agent'",
    42	        error_msg="Failed to set git user",
    43	        timeout=10,
    44	        check="raise",
    45	    )
    46	    env.communicate(input="rm -f model.patch", error_msg="Failed to remove model patch", timeout=10, check="raise")
    47	    env.communicate(
    48	        input=f"git checkout -b {branch_name}", error_msg="Failed to switch to new branch", timeout=10, check="raise"
    49	    )
    50	    env.communicate(input="git add .", error_msg="Failed to add commits", timeout=10, check="raise")
    51	    dry_run_flag = "--allow-empty" if _dry_run else ""
    52	    commit_msg = [
    53	        shlex.quote(f"Fix: {issue.title}"),
    54	        shlex.quote(f"Closes #{issue.number}"),
    55	    ]
    56	    out = env.communicate(
    57	        input=f"git commit -m {commit_msg[0]} -m  {commit_msg[1]} {dry_run_flag}",
    58	        error_msg="Failed to commit changes",
    59	        timeout=10,
    60	        check="raise",
    61	    )
    62	    logger.debug(f"Committed changes: {out}")
    63	
    64	    owner, repo, _ = _parse_gh_issue_url(issue_url)
    65	    # fixme: bring this back
    66	    # If `--repo_path` was specified with a different github URL, then the record will contain
    67	    # the forking user
    68	    forker = owner
    69	    head = branch_name
    70	    remote = "origin"
    71	    if forker != owner:
    72	        head = f"{forker}:{branch_name}"
    73	        token_prefix = ""
    74	        if token:
    75	            token_prefix = f"{token}@"
    76	        fork_url = f"https://{token_prefix}github.com/{forker}/{repo}.git"
    77	        logger.debug(f"Using fork: {fork_url}")
    78	        env.communicate(
    79	            input=f"git remote add fork {fork_url}",
    80	            error_msg="Failed to create new git remote",
    81	            timeout=10,
    82	        )
    83	        remote = "fork"
    84	    dry_run_prefix = "echo " if _dry_run else ""
    85	    out = env.communicate(
    86	        input=f"{dry_run_prefix} git push {remote} {branch_name}",
    87	        error_msg=(
    88	            "Failed to push branch to remote. Please check your token and permissions. "
    89	            "You might want to push to a fork with the push_gh_repo_url option."
    90	        ),
    91	        timeout=10,
    92	    )
    93	    logger.debug(f"Pushed commit to {remote=} {branch_name=}: {out}")
```

---

**🧑‍🚒 Response (25)**: 
I can see that there are several git commands being executed:
1. `git config user.email` and `git config user.name` (lines 40-45)
2. `git checkout -b` (lines 47-49)  
3. `git add .` (line 50)
4. `git commit` (lines 56-61)
5. `git remote add fork` (lines 78-82)
6. `git push` (lines 85-92)

All of these git commands will benefit from having the GITHUB_TOKEN set in the environment. The fix I implemented should handle this correctly.

However, I notice that on lines 74-76, there's also logic to construct a fork URL with the token embedded in it:

```python
token_prefix = ""
if token:
    token_prefix = f"{token}@"
fork_url = f"https://{token_prefix}github.com/{forker}/{repo}.git"
```

This is an alternative approach where the token is embedded directly in the git URL. However, this approach has security implications (the token might be visible in logs or error messages). The better approach is to use environment variables, which is what my fix does.

Let me also check if there are any existing tests that I should update:
**👀‍ Observation (25)**:
```
tests/test_run_hooks.py:from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
tests/test_run_hooks.py:    hook = OpenPRHook(config=OpenPRConfig(skip_if_commits_reference_issue=True))
```

---

**🧑‍🚒 Response (26)**: 

**👀‍ Observation (26)**:
```
Here's the result of running `cat -n` on /gatepoet__SWE-agent-web/tests/test_run_hooks.py:
     1	import os
     2	
     3	import pytest
     4	
     5	from sweagent.agent.problem_statement import GithubIssue
     6	from sweagent.run.hooks.open_pr import OpenPRConfig, OpenPRHook
     7	from sweagent.types import AgentRunResult
     8	
     9	
    10	@pytest.fixture
    11	def open_pr_hook_init_for_sop():
    12	    hook = OpenPRHook(config=OpenPRConfig(skip_if_commits_reference_issue=True))
    13	    hook._token = os.environ.get("GITHUB_TOKEN", "")
    14	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/1")
    15	    return hook
    16	
    17	
    18	@pytest.fixture
    19	def agent_run_result():
    20	    return AgentRunResult(
    21	        info={
    22	            "submission": "asdf",
    23	            "exit_status": "submitted",
    24	        },
    25	        trajectory=[],
    26	    )
    27	
    28	
    29	def test_should_open_pr_fail_submission(open_pr_hook_init_for_sop, agent_run_result):
    30	    hook = open_pr_hook_init_for_sop
    31	    agent_run_result.info["submission"] = None
    32	    assert not hook.should_open_pr(agent_run_result)
    33	
    34	
    35	def test_should_open_pr_fail_exit(open_pr_hook_init_for_sop, agent_run_result):
    36	    hook = open_pr_hook_init_for_sop
    37	    agent_run_result.info["exit_status"] = "fail"
    38	    assert not hook.should_open_pr(agent_run_result)
    39	
    40	
    41	def test_should_open_pr_fail_invalid_url(open_pr_hook_init_for_sop, agent_run_result):
    42	    hook = open_pr_hook_init_for_sop
    43	    agent_run_result.info["data_path"] = "asdf"
    44	    assert not hook.should_open_pr(agent_run_result)
    45	
    46	
    47	def test_should_open_pr_fail_closed(open_pr_hook_init_for_sop, agent_run_result):
    48	    hook = open_pr_hook_init_for_sop
    49	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/16")
    50	    assert not hook.should_open_pr(agent_run_result)
    51	
    52	
    53	def test_should_open_pr_fail_assigned(open_pr_hook_init_for_sop, agent_run_result):
    54	    hook = open_pr_hook_init_for_sop
    55	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/17")
    56	    assert not hook.should_open_pr(agent_run_result)
    57	
    58	
    59	def test_should_open_pr_fail_locked(open_pr_hook_init_for_sop, agent_run_result):
    60	    hook = open_pr_hook_init_for_sop
    61	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/18")
    62	    assert not hook.should_open_pr(agent_run_result)
    63	
    64	
    65	def test_should_open_pr_fail_has_pr(open_pr_hook_init_for_sop, agent_run_result):
    66	    hook = open_pr_hook_init_for_sop
    67	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/19")
    68	    assert not hook.should_open_pr(agent_run_result)
    69	
    70	
    71	def test_should_open_pr_success_has_pr_override(open_pr_hook_init_for_sop, agent_run_result):
    72	    hook = open_pr_hook_init_for_sop
    73	    hook._problem_statement = GithubIssue(github_url="https://github.com/swe-agent/test-repo/issues/19")
    74	    hook._config.skip_if_commits_reference_issue = False
    75	    assert hook.should_open_pr(agent_run_result)
    76
```

---

**🧑‍🚒 Response (27)**: 
I can see that the existing tests manually set `hook._token` in the fixture (line 13). This is fine and my change shouldn't break these tests since I'm only adding behavior to the `on_init` method. However, let me run the existing tests to make sure:
**👀‍ Observation (27)**:
```
/usr/local/bin/python: No module named pytest
```

---

**🧑‍🚒 Response (28)**: 
Let me check what test runner is available:
**👀‍ Observation (28)**:
```
[notice] A new release of pip is available: 24.0 -> 25.3
[notice] To update, run: pip install --upgrade pip
```

... (truncated due to length limit)
</details>